### PR TITLE
fix(pages): Update next.config.mjs to redirect docs to getting-started

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,6 +29,7 @@ const nextConfig = {
       destination: "/docs/getting-started",
       permanent: true,
     },
+  ]
 };
 
 export default withNextra(nextConfig);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,12 @@ const withNextra = nextra({
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
+  redirects: () => [
+    {
+      source: "/docs",
+      destination: "/docs/getting-started",
+      permanent: true,
+    },
 };
 
 export default withNextra(nextConfig);


### PR DESCRIPTION
rewrites is also a possibility, but they maintain the url.

using _meta.json is also possible, if preferable, but requires to rename `getting-started.mdx` to `index.mdx` for the desired behavior