### PR TITLE
docs(request-batching): small grammar fixes

### DIFF
--- a/pages/docs/core-concepts/batching-caching.mdx
+++ b/pages/docs/core-concepts/batching-caching.mdx
@@ -7,8 +7,7 @@ Before we dig into the Effect's solution to batching and caching let's start wit
 It is very common in apps to depend on a number of external data sources like:
 - HTTP APIs
 - Databases
-- FileSystems
-- etc
+- Filesystems
 
 ## Model Definition
 
@@ -84,12 +83,12 @@ const notifyOwner = (todo: Todo) => Effect.flatMap(
 ```
 
 <Callout type="info">
-In a real world scenario we may want to use a more precise types instead of directly using primitives for identifiers, check `@effect/data/Brand` and we may want to include more information in the errors.
+In a real world scenario we may want to use a more precise types instead of directly using primitives for identifiers (see `@effect/data/Brand`). We may also want to include more information in the errors.
 </Callout>
 
 ## Classic Approach
 
-Given such model we usually write up API calling functions (or Database, or whatever) like the following:
+Given such a model we usually write up functions to call some API (or database, etc.) like the following:
 
 ```ts twoslash
 // @include: model-1
@@ -98,10 +97,10 @@ Given such model we usually write up API calling functions (or Database, or what
 ```
 
 <Callout type="info">
-In a real world scenario we may not want to trust our APIs to actually return the expected data, for doing this properly you can use `@effect/schema/Schema` or similar alternatives such as `zod`.
+In a real world scenario we may not want to trust our APIs to actually return the expected data - for doing this properly you can use `@effect/schema/Schema` or similar alternatives such as `zod`.
 </Callout>
 
-When using the utilities we defined it is very normal to end up with code that looks like the following:
+When using the utilities we defined it is normal to end up with code that looks like the following:
 
 ```ts twoslash
 // @include: model-1
@@ -118,16 +117,16 @@ first fetches the `User` who owns the todo and then sends an email.
 
 We like writing code this way because it is **very expressive** and very easy to read, but is it **efficient**?
 
-This code will execute tons of individual API calls, most likely many todos will have the same owner and most likely
-our APIs also provide batched alternatives where for example you can request in one call as many users as you would like to.
+This code will execute tons of individual API calls. Many todos will likely have the same owner and
+our APIs may also provide batched alternatives where you can request as many users as you would like to in one call.
 
-So what can we do? rewrite all our code to use a different form of API? should we really do that?
+So what can we do? Rewrite all our code to use a different form of API? Should we really do that?
 
 Well **not anymore.**
 
 ## Declaring Requests
 
-Let's rewrite our example to be as efficient as humanly possible to imagine, we'll start by writing a model for the requests that our data sources support:
+Let's rewrite our example to be as efficient as possible - we'll start by writing a model for the requests that our data sources support:
 
 ```twoslash include requests
 import * as Request from "@effect/io/Request"
@@ -161,15 +160,15 @@ type ApiRequest = GetTodos | GetUserById | SendEmail
 ```
 
 <Callout type="info">
-We are using `@effect/data/Data` behind the scenes and given that requests will be compared using `@effect/data/Equal` for caching it is important to make sure they are compared by value, keep it in mind if you nest objects / arrays in your model (you should use Data.struct / Data.case / Data.tuple / etc).
+We are using `@effect/data/Data` behind the scenes and given that requests will be compared using `@effect/data/Equal` for caching it is important to make sure they are compared by value. If you nest objects / arrays in your model, you should use Data.struct / Data.case / Data.tuple / etc.
 </Callout>
 
 ## Declaring Request Resolvers
 
-Now that we have our requests defined it is time to tell `Effect` how to resolve those requests, that's where we would use a `RequestResolver`.
+Now that we have our requests defined it is time to tell `Effect` how to resolve those requests. That's where we would use a `RequestResolver`.
 
-Here we will define a single resolver per query, there is no right or wrong answer in how granular your resolvers should be
-but usually the split factor is based on what API calls can be batched or not.
+Here we will define a single resolver per query. There is no right or wrong answer in how granular your resolvers should be
+but usually you will split up your resolvers based on which API calls can be batched.
 
 ```twoslash include resolvers
 import * as RequestResolver from "@effect/io/RequestResolver"
@@ -237,7 +236,7 @@ const resolveSendEmail = RequestResolver.makeBatched((requests: SendEmail[]) =>
 ```
 
 <Callout type="info">
-Resolvers can also access context like any other `Effect` and there are many different ways of creating resolvers, you may want to check the reference documentation of the `@effect/io/RequestResolver` module next.
+Resolvers can also access context like any other `Effect` and there are many different ways of creating resolvers. You may want to check the reference documentation of the `@effect/io/RequestResolver` module next.
 </Callout>
 
 ## Defining Queries
@@ -321,13 +320,13 @@ const program = Effect.withRequestBatching("off")(
 
 ## Request Caching
 
-Up to this point we optimized how requests are executed but there is still a catch, we are not doing any caching.
+Up to this point we optimized how requests are executed but there is still a catch - we are not doing any caching.
 
 This leads to request duplication...
 
 Fortunately we also have a primitive for caching in `Effect` and we use that to automatically cache requests.
 
-Let's define a cache for the GetUserById to deduplicate the getUserCalls, we will assume an user doesn't change for 10 minutes.
+Let's define a cache for the GetUserById to deduplicate the getUserCalls. We will assume a user doesn't change for 10 minutes.
 
 ```twoslash include caches
 import * as Context from "@effect/data/Context"
@@ -357,7 +356,7 @@ const GetUserByIdCacheLive = Layer.effect(
 // @include: caches-1
 ```
 
-This way we created a cache that can handle up to 10_000 requests of type `GetUserById` each valid for a maximum of 10 minutes.
+We created a cache that can handle up to 10_000 requests of type `GetUserById` with each request valid for a maximum of 10 minutes.
 
 We now have to wire it up in our `getUserById` function:
 
@@ -416,11 +415,11 @@ const main = Effect.provideSomeLayer(GetUserByIdCacheLive)(
 )
 ```
 
-Should never execute twice the same `GetUserById` within a span of `10` minutes (assuming less than 10k users) while also making sure emails are sent in batches.
+This should never execute the same `GetUserById` twice within a span of `10` minutes (assuming less than 10k users) while also making sure emails are sent in batches.
 
 ## How is this possible?
 
-We recently introduced a new key primitive in the fiber that enables an execution to paused when it sees the program requires a request, in the process of pausing the fiber will reify its stack into a continuation that can be externally performed.
+We recently introduced a new key primitive in the fiber that enables an execution to pause when it sees the program requires a request. In the process of pausing, the fiber will reify its stack into a continuation that can be externally performed.
 
 ```ts twoslash
 // @include: model-1
@@ -461,24 +460,23 @@ const shipRequestsToBeExecutedAndWait = <R, E, A>(
 }
 ```
 
-By using the functions provided by the `@effect/io/RequestBlock` module one can combine requests from multiple blocked
-effects and by using the function `Effect.blocked(requests, continuation)` one can express an effect that is blocked
+By using the functions provided by the `@effect/io/RequestBlock` module, you can combine requests from multiple blocked
+effects. By using the function `Effect.blocked(requests, continuation)`, you can express an effect that is blocked
 on `requests` that should continue with `continuation`.
 
 ## Manipulating the Request Cache
 
 Some caches may be short lived and only locally provided to effects for the purpose of deduplication
-but some other ones can be long lived and last as long as your program survives, the request cache is implemented as we mentioned
-before by using the `@effect/io/Cache` module that allows for caching generic effect returning functions.
+but some other ones can be long lived and last as long as your program survives. The request cache is implemented by using the `@effect/io/Cache` module that allows for caching generic effect returning functions.
 
-In fact the `Request.Cache<R>` type is nothing more than an alias to `Cache.ConsumerCache<R, never, Deferred<unknown, unknown>>` and
-it is used internally by `Effect` to deduplicate requests.
+In fact, the `Request.Cache<R>` type is nothing more than an alias to `Cache.ConsumerCache<R, never, Deferred<unknown, unknown>>` and
+is used internally by `Effect` to deduplicate requests.
 
-When caches are managed, like in this case, one may not want to expose to the consumer the full power of the cache, namely the creation
+When caches are managed, like in this case, you may not want to expose to the consumer the full power of the cache. The creation
 of new entries is usually a delicate process that only the cache owner should manage but operating on keys with operations to invalidate
-existing entries, getting stats, etc are all valid to share, this is why the `ConsumerCache<R, E, A>` type is exposed.
+existing entries, getting stats, etc. are all valid to share, which is why the `ConsumerCache<R, E, A>` type is exposed.
 
-Let's explore how we would for example get statistics about the `UserCache` that we priorly defined and how we would invalidate some
+Let's explore how we would get statistics about the `UserCache` that we defined prior and how we would invalidate some
 entries manually.
 
 ```ts twoslash
@@ -510,7 +508,7 @@ const operateOnCache = Effect.gen(function* ($) {
 ## Using Cache Directly
 
 There are many cases where you have functions `(key: Key) => Effect<R, E, A>` that you would like to cache
-and not necessarily every case is a good fit for the request model, for example cases like non batchable API
+and not necessarily every case is a good fit for the request model shown above. For example, non-batchable API
 calls or intensive work.
 
 Let's see how we would go about using cache:
@@ -538,15 +536,15 @@ const program = Effect.gen(function* ($) {
 ```
 
 <Callout type="info">
-In order for the cache to correctly compare two `Key` values if you are not using primitives you should use types that implement
+In order for the cache to correctly compare two `Key` values if you are not using primitives (e.g. string, boolean, number), you should use types that implement
 the `@effect/data/Equal` interface.
 </Callout>
 
-There are many more methods available in the `Cache` module as a next step you should check out the reference docs.
+There are many more methods available in the `Cache` module. As a next step, check out the reference docs!
 
 ## Reference Docs
 
-Following the reference docs for each of the mentioned modules:
+The following are the reference docs for each of the mentioned modules:
 
 - [https://effect-ts.github.io/io/modules/Effect.ts.html](https://effect-ts.github.io/io/modules/Effect.ts.html)
 - [https://effect-ts.github.io/io/modules/Request.ts.html](https://effect-ts.github.io/io/modules/Request.ts.html)


### PR DESCRIPTION
Just as a warmup to get a sense of how the docs work, made some small readability and grammar fixes on the new request batching docs.
