### PR TITLE
Examples section, `common.ts`, direct link to API references

### DIFF
--- a/pages/docs/_meta.json
+++ b/pages/docs/_meta.json
@@ -3,6 +3,7 @@
   "core-concepts": "Core Concepts",
   "utility-modules": "Utility Modules",
   "advanced-concepts": "Advanced Concepts",
+  "examples": "Examples",
   "faq": "FAQ",
   "api-reference": "API Reference",
   "style-guide": "Style Guide",

--- a/pages/docs/api-reference/_meta.json
+++ b/pages/docs/api-reference/_meta.json
@@ -1,0 +1,27 @@
+{
+  "@effect/data": {
+    "title": "@effect/data ↗",
+    "href": "https://effect-ts.github.io/data/docs/modules",
+    "newWindow": true
+  },
+  "@effect/io": {
+    "title": "@effect/io ↗",
+    "href": "https://effect-ts.github.io/io/docs/modules",
+    "newWindow": true
+  },
+  "@effect/schema": {
+    "title": "@effect/schema ↗",
+    "href": "https://effect-ts.github.io/schema/docs/modules",
+    "newWindow": true
+  },
+  "@effect/stm": {
+    "title": "@effect/stm ↗",
+    "href": "https://effect-ts.github.io/stm/docs/modules",
+    "newWindow": true
+  },
+  "@effect/stream": {
+    "title": "@effect/stream ↗",
+    "href": "https://effect-ts.github.io/stream/docs/modules",
+    "newWindow": true
+  }
+}

--- a/pages/docs/examples/_meta.json
+++ b/pages/docs/examples/_meta.json
@@ -1,0 +1,3 @@
+{
+  "fetch-wrapper": "Fetch wrapper"
+}

--- a/pages/docs/examples/_meta.json
+++ b/pages/docs/examples/_meta.json
@@ -1,3 +1,23 @@
 {
-  "fetch-wrapper": "Fetch wrapper"
+  "fetch-wrapper": "Fetch wrapper",
+  "tim-smart/dfx": {
+    "title": "dfx ↗",
+    "href": "https://github.com/tim-smart/dfx",
+    "newWindow": true
+  },
+  "tim-smart/effect-http": {
+    "title": "effect-http ↗",
+    "href": "https://github.com/tim-smart/effect-http",
+    "newWindow": true
+  },
+  "Effect-TS/discord-bot": {
+    "title": "discord-bot ↗",
+    "href": "https://github.com/Effect-TS/discord-bot",
+    "newWindow": true
+  },
+  "contentlayerdev/contentlayer": {
+    "title": "contentlayer ↗",
+    "href": "https://github.com/contentlayerdev/contentlayer",
+    "newWindow": true
+  }
 }

--- a/pages/docs/examples/fetch-wrapper.mdx
+++ b/pages/docs/examples/fetch-wrapper.mdx
@@ -1,0 +1,123 @@
+# `fetch` wrapper
+
+This example shows how to implement a wrapper around `fetch` using `effect-ts`.
+
+```ts
+export * as Effect from "@effect/io/Effect";
+
+class FetchError {
+  readonly _tag = "FetchError";
+  constructor(readonly error: unknown) {}
+}
+
+/** Perform a `fetch` request */
+export const request = (input: RequestInfo, init?: RequestInit) =>
+  Effect.tryCatchPromise(
+    () => fetch(input, init),
+    (error) => new FetchError(error)
+  );
+
+
+class JsonBodyError {
+  readonly _tag = "JsonBodyError";
+  constructor(readonly error: unknown) {}
+}
+
+/** Convert `Response` to json using the `json` method */
+export const jsonBody = (input: Response) =>
+  Effect.tryCatchPromise(
+    (): Promise<unknown> => input.json(),
+    (error) => new JsonBodyError(error)
+  );
+
+
+class ResponseTextError {
+  readonly _tag = "ResponseTextError";
+  constructor(readonly error: unknown) {}
+}
+
+/** Convert `Response` to `string` using the `text` method */
+export const responseText = (input: Response) =>
+  Effect.tryCatchPromise(
+    () => input.text(),
+    (error) => new ResponseTextError(error)
+  );
+```
+
+This module exports 3 functions: `request`, `jsonBody`, `responseText`.
+
+All of these 3 functions use the [`tryCatchPromise`](https://effect-ts.github.io/io/modules/Effect.ts.html#trycatchpromise) method from the [`Effect`](https://effect-ts.github.io/io/modules/Effect.ts.html) module.
+
+By using `effect-ts` we keep track of each request response and possible errors **directly from the return type**:
+
+- `request` returns `Effect.Effect<never, FetchError, Response>`
+  - `never`: No environment required
+  - `FetchError`: It may fail with a `FetchError`
+  - `Response`: It returns a `Response` when successful 
+
+```ts
+class FetchError {
+  readonly _tag = "FetchError";
+  constructor(readonly error: unknown) {}
+}
+
+/** `Effect.Effect<never, FetchError, Response>` */
+export const request = (input: RequestInfo, init?: RequestInit) =>
+  Effect.tryCatchPromise(
+    () => fetch(input, init),
+    (error) => new FetchError(error)
+  );
+```
+
+- `jsonBody` returns `Effect.Effect<never, JsonBodyError, unknown>`
+  - `never`: No environment required
+  - `JsonBodyError`: It may fail with a `JsonBodyError`
+  - `unknown`: It returns `unknown` when successful 
+
+```ts
+class JsonBodyError {
+  readonly _tag = "JsonBodyError";
+  constructor(readonly error: unknown) {}
+}
+
+/** `Effect.Effect<never, JsonBodyError, unknown>` */
+export const jsonBody = (input: Response) =>
+  Effect.tryCatchPromise(
+    (): Promise<unknown> => input.json(),
+    (error) => new JsonBodyError(error)
+  );
+```
+
+- `request` returns `Effect.Effect<never, ResponseTextError, string>`
+  - `never`: No environment required
+  - `ResponseTextError`: It may fail with a `ResponseTextError`
+  - `string`: It returns a `string` when successful 
+
+```ts
+class ResponseTextError {
+  readonly _tag = "ResponseTextError";
+  constructor(readonly error: unknown) {}
+}
+
+/** `Effect.Effect<never, ResponseTextError, string>` */
+export const responseText = (input: Response) =>
+  Effect.tryCatchPromise(
+    () => input.text(),
+    (error) => new ResponseTextError(error)
+  );
+```
+
+***
+
+You can re-export this module from `common.ts` ([read more](/docs/getting-started#using-effect-in-your-project) about how to use `effect-ts` in your project):
+
+```ts
+/** common.ts */
+export * as Http from "./http";
+```
+
+And then import the `Http` module from `common.ts`:
+
+```ts
+import { Http } from "./common";
+```

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -15,7 +15,37 @@ npm install @effect/io
 npm install @effect/data
 ```
 
-You can find the full list on GitHub.
+You can find [the full list on GitHub](https://github.com/Effect-TS) and in the [API Reference section](/docs/api-reference).
+
+## Using effect in your project
+Since effect is a collection of many different modules, it is a common pattern to create a `common.ts` file that exports the modules used from `@effect/*` as well as utility modules:
+
+```ts
+/** Export `@effect/*` modules */
+export * as Chunk from "@effect/data/Chunk";
+export * as Context from "@effect/data/Context";
+export * as Data from "@effect/data/Data";
+export * as Option from "@effect/data/Option";
+export * as Effect from "@effect/io/Effect";
+export * as Schema from "@effect/schema/Schema";
+
+/** Export `flow` and `pipe` separately */
+export { flow, pipe } from "@effect/data/Function";
+
+/** Export utility modules */
+export * as Http from "./fetch";
+export * as HTMLParser from "./html-parser";
+```
+
+Then you can use it as follows:
+
+```ts
+import { Effect, HTMLParser, Option, pipe } from "./common";
+```
+
+<Callout emoji="⚠️">
+  Pay attention to avoid cyclical dependencies by not using the `common` module in any of the modules that it re-exports. Tools like `eslint` and `madge` may help you prevent this mistake.
+</Callout>
 
 ## Start Reading
 

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -57,4 +57,4 @@ To see the full API reference docs, check out the [API Reference](./api-referenc
 
 ## External
 
-You can also connect with the Effect community on Discord or check out our GitHub for more.
+You can also connect with the Effect community on [Discord](https://discord.gg/effect-ts) or check out our [GitHub](https://github.com/Effect-TS) for more.


### PR DESCRIPTION
Following the suggestions from the [Content Structure issue](https://github.com/Effect-TS/website/issues/59#issuecomment-1574796631), this PR adds the following:
- How to use `effect-ts` by creating a `common.ts` file ([from Micheal's video](https://youtu.be/zrNr3JVUc8I?t=1684))
- Added `Examples` section
  - Added fetch wrapper example
  - Added link to projects using `effect-ts`
- Added direct link in the navigation menu to each effect module 

<img width="286" alt="Screenshot 2023-06-06 at 19 54 24" src="https://github.com/Effect-TS/website/assets/10065056/91476b8f-a4b9-4c8a-968f-60f004e62cdb">

<img width="1161" alt="Screenshot 2023-06-06 at 19 55 13" src="https://github.com/Effect-TS/website/assets/10065056/7cb7bc14-042e-43b3-87a1-9b7b0dae953c">
