### PR TITLE
Favor `_` over `$` for `Effect.gen` in style guide

### DIFF
--- a/pages/docs/how-to-guides/idiomatic-code.mdx
+++ b/pages/docs/how-to-guides/idiomatic-code.mdx
@@ -86,41 +86,41 @@ Effect has a unique imperative API to solve for the problem of lots of nested ca
 import * as Effect from "@effect/io/Effect"
 import * as Random from "@effect/io/Random"
 
-const example = Effect.gen(function* ($) {
-  const n = yield* $(Random.next())
+const example = Effect.gen(function* (_) {
+  const n = yield* _(Random.next())
   if (n > 0.5) {
-    return yield* $(Effect.succeed("yay!"))
+    return yield* _(Effect.succeed("yay!"))
   } else {
-    return yield* $(Effect.fail("oh no!"))
+    return yield* _(Effect.fail("oh no!"))
   }
 })
 ```
 
-Note the `yield*`, which is used to yield the next value from the generator. Additionally, one can also observe the `$` argument passed to `Effect.gen`, which is just a function that serves as an "adapter" that allows TypeScript to track our Effect types. When yielding an Effect, you must pass the Effect you would like to `yield*` to the adapter function to ensure that TypeScript can properly infer the types.
+Note the `yield*`, which is used to yield the next value from the generator. Additionally, one can also observe the `_` argument passed to `Effect.gen`, which is just a function that serves as an "adapter" that allows TypeScript to track our Effect types. When yielding an Effect, you must pass the Effect you would like to `yield*` to the adapter function to ensure that TypeScript can properly infer the types.
 
 This way, you can write in a more imperative style rather than having to use `pipe` and `flatMap`.
 
 <Callout type="info">
-  The dollar sign is just an argument name convention and is not a special
-  symbol in Effect. You are free to name it whatever you want (e.g. using an
-  underscore, etc.). The current convention is to use `$` as the argument name.
+  The `_` symbol is just an argument name convention and is not a special
+  symbol in Effect. You are free to name it whatever you want (e.g. `$`, etc.).
+  The current convention is to use `_` as the argument name.
 </Callout>
 
 #### Using the Adapter Argument as a `pipe`
 
-One thing to note is that the `$` argument also can be used as a pipe function. In the following example, `Random.next()` is piped into `Effect.either`.
+One thing to note is that the `_` argument also can be used as a pipe function. In the following example, `Random.next()` is piped into `Effect.either`.
 
 ```ts
 import * as Effect from "@effect/io/Effect"
 import * as Random from "@effect/io/Random"
 import * as Either from "@effect/data/Either"
 
-const example = Effect.gen(function* ($) {
-  const n = yield* $(Random.next(), Effect.either)
+const example = Effect.gen(function* (_) {
+  const n = yield* _(Random.next(), Effect.either)
   if (Either.isRight(n)) {
-    return yield* $(Effect.succeed("yay!"))
+    return yield* _(Effect.succeed("yay!"))
   } else {
-    return yield* $(Effect.fail("oh no!"))
+    return yield* _(Effect.fail("oh no!"))
   }
 })
 ```


### PR DESCRIPTION
The API focus group is moving towards recommending `_` over `$` for `Effect.gen`. 

This PR makes the necessary changes to the style guide to reflect this.