### PR TITLE
update 'Effect Essentials' to new api

### DIFF
--- a/pages/docs/essentials/control-flow.mdx
+++ b/pages/docs/essentials/control-flow.mdx
@@ -65,9 +65,7 @@ import * as Effect from "@effect/io/Effect"
 import * as Random from "@effect/io/Random"
 
 // Effect<never, never, Option.Option<number>>
-const randomIntOption = Effect.whenEffect(Random.nextBoolean())(
-  Random.nextInt()
-)
+const randomIntOption = Effect.whenEffect(Random.nextBoolean)(Random.nextInt)
 ```
 
 The `Effect.when` and `Effect.whenEffect` operators allow us to conditionally execute effects based on a given predicate or an effectful predicate, respectively.
@@ -87,11 +85,11 @@ import { pipe } from "@effect/data/Function"
 import * as Effect from "@effect/io/Effect"
 import * as Random from "@effect/io/Random"
 
-const onTrue = Effect.logInfo("Head")
-const onFalse = Effect.logInfo("Tail")
+const onTrue = Effect.log("Head")
+const onFalse = Effect.log("Tail")
 
 // Effect<never, never, void>
-const flipTheCoin = pipe(Random.nextBoolean(), Effect.ifEffect(onTrue, onFalse))
+const flipTheCoin = pipe(Random.nextBoolean, Effect.if({ onTrue, onFalse }))
 ```
 
 In this example, we generate a random boolean value using `Random.nextBoolean()`. If the value is `true`, the effect `onTrue` will be executed, which logs "Head". Otherwise, if the value is `false`, the effect `onFalse` will be executed, logging "Tail".
@@ -103,7 +101,7 @@ In this example, we generate a random boolean value using `Random.nextBoolean()`
 The `Effect.loop` operator allows you to repeatedly change the state based on an `inc` function until a condition given by the `cont` function is evaluated to `true`:
 
 ```ts
-Effect.loop(initial, cont, inc, body)
+Effect.loop(initial, {while, step, body})
 ```
 
 It collects all intermediate states in an array and returns it as the final result.
@@ -111,13 +109,15 @@ It collects all intermediate states in an array and returns it as the final resu
 We can think of `Effect.loop` as a moral equivalent of a `while` loop in JavaScript:
 
 ```ts
-let s = initial
-let result = []
+let state: T = initial
+let collection = [] as readonly T[]
 
-while (cont(s)) {
-  as = [...result, body(s)]
-  s = inc(s)
+while (while(state)) {
+  collection = [body(state), ...as]
+  state = step(state)
 }
+
+return Array.reverse(collection)
 ```
 
 Here's an example of how it works:
@@ -128,9 +128,11 @@ import * as Effect from "@effect/io/Effect"
 // Effect<never, never, number[]>
 const result = Effect.loop(
   1, // Initial state
-  (n) => n <= 5, // Condition to continue looping
-  (n) => n + 1, // State update function
-  (n) => Effect.succeed(n) // Effect to be performed on each iteration
+  {
+    while: (n) => n <= 5, // Condition to continue looping
+    step: (n) => n + 1, // State update function
+    body: (n) => Effect.succeed(n), // Effect to be performed on each iteration
+  }
 )
 
 console.log(Effect.runSync(result)) // Output: [1, 2, 3, 4, 5]
@@ -138,9 +140,9 @@ console.log(Effect.runSync(result)) // Output: [1, 2, 3, 4, 5]
 
 In this example, the loop starts with an initial state of `1`. The loop continues as long as the condition `n <= 5` is `true`, and in each iteration, the state `n` is incremented by `1`. The effect `Effect.succeed(n)` is performed on each iteration, collecting all intermediate states in an array.
 
-You can also use the `Effect.loopDiscard` operator if you're not interested in collecting the intermediate results. It discards all intermediate states and returns `undefined` as the final result.
+You can also use the `discard` option if you're not interested in collecting the intermediate results. It discards all intermediate states and returns `undefined` as the final result.
 
-Here's an example using `Effect.loopDiscard`:
+Here's an example using `discard: true`:
 
 ```ts
 import * as Effect from "@effect/io/Effect"
@@ -175,7 +177,7 @@ We can think of `Effect.iterate` as a moral equivalent of a `while` loop in Java
 ```ts
 let result = initial
 
-while (cont(result)) {
+while (while(result)) {
   result = body(result)
 }
 
@@ -190,8 +192,10 @@ import * as Effect from "@effect/io/Effect"
 // Effect<never, never, number>
 const result = Effect.iterate(
   1, // Initial state
-  (n) => n <= 5, // Condition to continue iterating
-  (n) => Effect.succeed(n + 1) // Operation to change the state
+  {
+    while: (n) => n <= 5, // Condition to continue iterating
+    body: (n) => Effect.succeed(n + 1), // Operation to change the state
+  }
 )
 
 console.log(Effect.runSync(result)) // Output: 6
@@ -230,14 +234,16 @@ In this example, we have an array `[1, 2, 3, 4, 5]`, and for each element `index
 
 The `Effect.forEach` combinator collects the results of each effectful operation in an array, which is why the final output is `[ 2, 4, 6, 8, 10 ]`.
 
-We also have the `Effect.forEachDiscard` combinator, which is similar to `Effect.forEach` but discards the results of each effectful operation:
+We also have the `discard` option, which when set to `true` discards the results of each effectful operation:
 
 ```ts
 import * as Effect from "@effect/io/Effect"
 
 // Effect<never, never, void>
-const result2 = Effect.forEachDiscard([1, 2, 3, 4, 5], (index) =>
-  Effect.sync(() => console.log(`Currently at index ${index}`))
+const result2 = Effect.forEach(
+  [1, 2, 3, 4, 5],
+  (index) => Effect.sync(() => console.log(`Currently at index ${index}`)),
+  { discard: true }
 )
 
 console.log(Effect.runSync(result2))

--- a/pages/docs/essentials/creating.mdx
+++ b/pages/docs/essentials/creating.mdx
@@ -68,20 +68,31 @@ This is because `program` represents the action of writing to the console, but n
 
 <Error>The thunk passed to `sync` should never throw errors.</Error>
 
-If the synchronous computation within the thunk may throw an error, you can use the `Effect.tryCatch(thunk, onError){:ts}` constructor
-to control what gets propagated to the error channel:
+If the synchronous computation within the thunk may throw an error, you can use the `Effect.try(thunk){:ts}`constructor.
+If an error is caught it will be propagated to the error channel as `unknown`:
+
+```ts
+import * as Effect from "@effect/io/Effect"
+
+// Effect<never, unknown, any>
+const program = Effect.try(
+  () => JSON.parse("") // JSON.parse may throw for bad input
+)
+```
+
+If you want more control over what gets propagated to the error channel, you can an overload of `Effect.try` that takes a remapping function:
 
 ```ts
 import * as Effect from "@effect/io/Effect"
 
 // Effect<never, Error, any>
-const program = Effect.tryCatch(
-  () => JSON.parse(""), // JSON.parse may throw for bad input
-  (unknown) => new Error(`something went wrong ${unknown}`) // remap the error
-)
+const program = Effect.try({
+  try: () => JSON.parse(""), // JSON.parse may throw for bad input
+  catch: (unknown) => new Error(`something went wrong ${unknown}`), // remap the error
+})
 ```
 
-You can think of `tryCatch` as a similar pattern to the traditional `try-catch` block in JavaScript:
+You can think of this as a similar pattern to the traditional try-catch block in JavaScript:
 
 ```ts
 try {
@@ -104,8 +115,8 @@ const program = Effect.promise(() => Promise.resolve(42))
 
 <Error>The `Promise` passed to `promise` should never reject.</Error>
 
-If the `Promise` within the thunk may reject, you can use the `Effect.tryPromise(thunk){:ts}` constructor
-to handle the error propagation (as `unknown`):
+If the `Promise` within the thunk may reject, you can use the `Effect.tryPromise(thunk){:ts}`constructor.
+If an error is caught it will be propagated to the error channel as `unknown`:
 
 ```ts
 import * as Effect from "@effect/io/Effect"
@@ -116,16 +127,16 @@ const program = Effect.tryPromise(() =>
 )
 ```
 
-If you want more control over what gets propagated to the error channel, you can use the `Effect.tryCatchPromise(thunk, onReject){:ts}` constructor:
+If you want more control over what gets propagated to the error channel, you can an overload of `Effect.tryPromise` that takes a remapping function:
 
 ```ts
 import * as Effect from "@effect/io/Effect"
 
 // Effect<never, Error, Response>
-const program = Effect.tryCatchPromise(
-  () => fetch("https://jsonplaceholder.typicode.com/todos/1"),
-  (unknown) => new Error(`something went wrong ${unknown}`) // remap the error
-)
+const program = Effect.tryPromise({
+  try: () => fetch("https://jsonplaceholder.typicode.com/todos/1"),
+  catch: (unknown) => new Error(`something went wrong ${unknown}`), // remap the error
+})
 ```
 
 ## From a callback
@@ -164,16 +175,16 @@ based on the return value inside the callback body. Annotating the types ensures
 
 The table provides a summary of the available constructors, along with their input and output types, allowing you to choose the appropriate function based on your needs.
 
-| **Name**          | **Given**                               | **To**                      |
-| ----------------- | --------------------------------------- | --------------------------- |
-| `succeed`         | `A`                                     | `Effect<never, never, A>`   |
-| `fail`            | `E`                                     | `Effect<never, E, never>`   |
-| `sync`            | `() => A`                               | `Effect<never, never, A>`   |
-| `tryCatch`        | `() => A`, `unknown => E`               | `Effect<never, E, A>`       |
-| `promise`         | `() => Promise<A>`                      | `Effect<never, never, A>`   |
-| `tryPromise`      | `() => Promise<A>`                      | `Effect<never, unknown, A>` |
-| `tryCatchPromise` | `() => Promise<A>`, `unknown => E`      | `Effect<never, E, A>`       |
-| `async`           | `(resume: Effect<never, E, A>) => void` | `Effect<never, E, A>`       |
+| **Name**                      | **Given**                                           | **To**                      |
+| ----------------------------- | --------------------------------------------------- | --------------------------- |
+| `succeed`                     | `A`                                                 | `Effect<never, never, A>`   |
+| `fail`                        | `E`                                                 | `Effect<never, E, never>`   |
+| `sync`                        | `() => A`                                           | `Effect<never, never, A>`   |
+| `try`                         | `() => A`, `unknown => E`                           | `Effect<never, unknown, A>` |
+| `try` (catch overload)        | `{try: () => A, catch: unknown => E}{:ts}`          | `Effect<never, E, A>`       |
+| `tryPromise`                  | `() => Promise<A>`                                  | `Effect<never, unknown, A>` |
+| `tryPromise` (catch overload) | `{try: () => Promise<A>, catch: unknown => E}{:ts}` | `Effect<never, E, A>`       |
+| `async`                       | `(resume: Effect<never, E, A>) => void`             | `Effect<never, E, A>`       |
 
 You can find the complete list of constructors [here](https://effect-ts.github.io/io/modules/Effect.ts.html#constructors).
 

--- a/pages/docs/essentials/exit.mdx
+++ b/pages/docs/essentials/exit.mdx
@@ -19,10 +19,11 @@ const simulatedSuccess = Effect.runSyncExit(Effect.succeed(1))
 
 pipe(
   simulatedSuccess,
-  Exit.match(
-    (cause) => console.error(`Exited with failure state: ${cause._tag}`),
-    (value) => console.log(`Exited with success value: ${value}`)
-  )
+  Exit.match({
+    onFailure: (cause) =>
+      console.error(`Exited with failure state: ${cause._tag}`),
+    onSuccess: (value) => console.log(`Exited with success value: ${value}`),
+  })
 )
 // Output: "Exited with success value: 1"
 
@@ -31,10 +32,11 @@ const simulatedFailure = Effect.runSyncExit(Effect.fail("error"))
 
 pipe(
   simulatedFailure,
-  Exit.match(
-    (cause) => console.error(`Exited with failure state: ${cause._tag}`),
-    (value) => console.log(`Exited with success value: ${value}`)
-  )
+  Exit.match({
+    onFailure: (cause) =>
+      console.error(`Exited with failure state: ${cause._tag}`),
+    onSuccess: (value) => console.log(`Exited with success value: ${value}`),
+  })
 )
 // Output: "Exited with failure state: Annotated"
 ```

--- a/pages/docs/essentials/running.mdx
+++ b/pages/docs/essentials/running.mdx
@@ -36,30 +36,6 @@ Effect.runSync(Effect.fail("error")) // throws
 Effect.runSync(Effect.promise(() => Promise.resolve(1))) // throws
 ```
 
-## runSyncEither
-
-The `runSyncEither` function is used to execute an Effect synchronously, which means it runs immediately and returns the result as an `Either`
-(a data type used to represent the possibility of either a successful value or a failure value).
-
-```ts
-import * as Effect from "@effect/io/Effect"
-
-Effect.runSyncEither(Effect.succeed(1)) // Either.right(1))
-
-Effect.runSyncEither(Effect.fail("error")) // Either.left("error")
-```
-
-<Warning>
-  `runSyncEither` will throw an error if your Effect performs any asynchronous
-  tasks and the execution will not proceed beyond that asynchronous task.
-</Warning>
-
-```ts
-import * as Effect from "@effect/io/Effect"
-
-Effect.runSyncEither(Effect.promise(() => Promise.resolve(1))) // throws
-```
-
 ## runSyncExit
 
 The `runSyncExit` function is used to execute an Effect synchronously, which means it runs immediately and returns the result as an [`Exit`](exit)
@@ -103,20 +79,6 @@ import * as Effect from "@effect/io/Effect"
 Effect.runPromise(Effect.fail("error")) // rejects
 ```
 
-## runPromiseEither
-
-The `runPromiseEither` function is used to execute an Effect and obtain the result as a `Promise` that resolves to an `Either`
-(a data type used to represent the possibility of either a successful value or a failure value).
-
-```ts
-import * as Effect from "@effect/io/Effect"
-import * as Either from "@effect/data/Either"
-
-await Effect.runPromiseEither(Effect.succeed(1)) // Either.right(1)
-
-await Effect.runPromiseEither(Effect.fail("error")) // Either.left("error")
-```
-
 ## runPromiseExit
 
 The `runPromiseExit` function is used to execute an Effect and obtain the result as a `Promise` that resolves to an [`Exit`](exit)
@@ -142,14 +104,12 @@ await Effect.runPromiseExit(Effect.fail("error")) // Exit.fail(...)
 
 The table provides a summary of the available `run*` functions, along with their input and output types, allowing you to choose the appropriate function based on your needs.
 
-| **Name**           | **Given**             | **To**                  |
-| ------------------ | --------------------- | ----------------------- |
-| `runSync`          | `Effect<never, E, A>` | `A`                     |
-| `runSyncEither`    | `Effect<never, E, A>` | `Either<E, A>`          |
-| `runSyncExit`      | `Effect<never, E, A>` | `Exit<E, A>`            |
-| `runPromise`       | `Effect<never, E, A>` | `Promise<A>`            |
-| `runPromiseEither` | `Effect<never, E, A>` | `Promise<Either<E, A>>` |
-| `runPromiseExit`   | `Effect<never, E, A>` | `Promise<Exit<E, A>>`   |
+| **Name**         | **Given**             | **To**                |
+| ---------------- | --------------------- | --------------------- |
+| `runSync`        | `Effect<never, E, A>` | `A`                   |
+| `runSyncExit`    | `Effect<never, E, A>` | `Exit<E, A>`          |
+| `runPromise`     | `Effect<never, E, A>` | `Promise<A>`          |
+| `runPromiseExit` | `Effect<never, E, A>` | `Promise<Exit<E, A>>` |
 
 You can find the complete list of `run*` functions [here](https://effect-ts.github.io/io/modules/Effect.ts.html#execution).
 

--- a/pages/docs/essentials/using-generators.mdx
+++ b/pages/docs/essentials/using-generators.mdx
@@ -173,7 +173,7 @@ import * as Random from "@effect/io/Random"
 
 const program = Effect.gen(function* (_) {
   const n = yield* _(
-    Random.next(),
+    Random.next,
     Effect.map((n) => n * 2)
   )
   if (n > 0.5) {
@@ -190,10 +190,10 @@ This approach is useful to avoid excessive notation by using both the `_` helper
 const program = Effect.gen(function* (_) {
   const n = yield* _(
     pipe(
-      Random.next(),
+      Random.next,
       Effect.map((n) => n * 2)
     )
   )
-  ...
-}
+  // ...
+})
 ```


### PR DESCRIPTION
this pr:

- updates all outdate code and explanations in 'Effect Essentials' to match the [new api](https://github.com/Effect-TS/io/pull/461)
- modified examples where `random.next`, `nextBoolean` and `nextInt` were called as methods when they are just values

to ensure everything is correct [here is a typescript playground with every single snippet from this section with no errors](https://tsplay.dev/m07xRN) (give it a sec to load the imported packages)

also

I was unable to start my dev server due to some [nasty (webpack?) errors ](https://pastebin.com/0rQzKJP1), so I dont know exactly how things will look but the changes are pretty minor so I assume everything should be fine

