### PR TITLE
Minor corrections to code samples for built-in-schedules.mdx

### DIFF
--- a/pages/docs/guide/scheduling/built-in-schedules.mdx
+++ b/pages/docs/guide/scheduling/built-in-schedules.mdx
@@ -24,7 +24,7 @@ A schedule that always recurs and produces number of recurrence at each run.
 import * as Schedule from "@effect/io/Schedule"
 import * as Effect from "@effect/io/Effect"
 
-const schedule = Schedule.forever()
+const schedule = Schedule.forever
 
 Effect.runPromise(Effect.repeat(logDelay, schedule))
 /*
@@ -48,7 +48,7 @@ A schedule that recurs one time.
 import * as Schedule from "@effect/io/Schedule"
 import * as Effect from "@effect/io/Effect"
 
-const schedule = Schedule.once()
+const schedule = Schedule.once
 
 Effect.runPromise(Effect.repeat(logDelay, schedule))
 /*
@@ -171,9 +171,7 @@ import * as Effect from "@effect/io/Effect"
 
 const schedule = Schedule.fibonacci("10 millis")
 
-Effect.runPromise(Schedule.run(schedule, 0, [1, 2, 3, 4, 5, 6])).then(
-  console.log
-)
+Effect.runPromise(Effect.repeat(logDelay, schedule))
 /*
 delay: 3
 delay: 17 < fibonacci


### PR DESCRIPTION
Minor corrections to code samples:

  * In https://effect.website/docs/guide/scheduling/built-in-schedules#forever
     Remove () in use of Schedule.forever to prevent error:
    
```
    TSError: ⨯ Unable to compile TypeScript: error TS2349: This expression is not callable. 
    Type 'Schedule<never, unknown, number>' has no call signatures.
    12 const schedule = Schedule.forever() ~~~~~~~
```

  * In https://effect.website/docs/guide/scheduling/built-in-schedules#once 
     Remove () in use of Schedule.once to prevent error:

```    
    error TS2349: This expression is not callable. 
    Type 'Schedule<never, unknown, void>' has no call signatures.
    12 const schedule = Schedule.once() ~~~~
```

  * In https://effect.website/docs/guide/scheduling/built-in-schedules#fibonacci Replace

```
      Effect.runPromise(Schedule.run(schedule, 0, [1, 2, 3, 4, 5, 6])).then(
        console.log
      )
```

with

```
      Effect.runPromise(Effect.repeat(logDelay, schedule))
```

so that output matches expected output shown in comments instead of

```     
      {
        _tag: 'Chunk',
        values: [
          { _tag: 'Duration', value: [Object] },
          { _tag: 'Duration', value: [Object] },
          { _tag: 'Duration', value: [Object] },
          { _tag: 'Duration', value: [Object] },
          { _tag: 'Duration', value: [Object] },
          { _tag: 'Duration', value: [Object] }
        ]
      }
```