### PR TITLE
Add missing ) in Effect.promise example (creating.mdx)

### DIFF
--- a/pages/docs/essentials/creating.mdx
+++ b/pages/docs/essentials/creating.mdx
@@ -160,7 +160,7 @@ const program = Effect.promise(() => new Promise((resolve) => {
   setTimeout(() => {
     resolve("Async operation completed successfully!")
   }, 2000)
-})
+}))
 ```
 
 The `program` value has the type `Effect<never, never, number>` and can be interpreted as an effect that:


### PR DESCRIPTION
The first code example in the "Modeling Asynchronous Effects" section https://www.effect.website/docs/essentials/creating#effectpromise is missing a trailing ')':

```
% ts-node
> .editor
// Entering editor mode (Ctrl+D to finish, Ctrl+C to cancel)
import { Effect } from "effect"
 
// Effect<never, never, number>
const program = Effect.promise(() => new Promise((resolve) => {
  setTimeout(() => {
    resolve("Async operation completed successfully!")
  }, 2000)
})

Uncaught:
<repl>.ts:13:1 - error TS1005: ')' expected.
```

This change adds the necessary )