### PR TITLE
Add  entry in the creating Effect cheatsheet

### DIFF
--- a/pages/docs/essentials/creating.mdx
+++ b/pages/docs/essentials/creating.mdx
@@ -242,6 +242,7 @@ The table provides a summary of the available constructors, along with their inp
 | `sync`                  | `() => A`                          | `Effect<never, never, A>`   |
 | `try`                   | `() => A`                          | `Effect<never, unknown, A>` |
 | `try` (overload)        | `() => A`, `unknown => E`          | `Effect<never, E, A>`       |
+| `promise`               | `() => Promise<A>`                 | `Effect<never, never, A>`   |
 | `tryPromise`            | `() => Promise<A>`                 | `Effect<never, unknown, A>` |
 | `tryPromise` (overload) | `() => Promise<A>`, `unknown => E` | `Effect<never, E, A>`       |
 | `async`                 | `Effect<never, E, A> => void`      | `Effect<never, E, A>`       |


### PR DESCRIPTION
While reading the [Creating Effects](https://effect.website/docs/essentials/creating) page on `effect.website`, I noticed that `Effect.promise` was missing in the [Cheatsheet](https://effect.website/docs/essentials/creating#cheatsheet).

This PR aims to fix that. Below an image of how it appears locally, running `pnpm dev`.

![Fri Jul 14 10:15:27 PM CEST 2023](https://github.com/Effect-TS/website/assets/4209616/3b5e3be4-cca5-4a23-b3df-2056cf8ae327)
