### PR TITLE
Fix comment padding in "Coming from ZIO"

### DIFF
--- a/pages/docs/coming-from-zio.mdx
+++ b/pages/docs/coming-from-zio.mdx
@@ -9,7 +9,7 @@ In Effect, we represent the environment required to run an `Effect` workflow as 
 ```ts
 import { Effect } from "effect"
 
-//                 v---------v---- `R` is a union of Console | Logger
+//                           v---------v---- `R` is a union of Console | Logger
 type Http = Effect.Effect<Console | Logger, IOError | HttpError, Response>
 
 type Response = Record<string, string>


### PR DESCRIPTION
The following comment in the "Coming from ZIO" page doesn't have enough padding:

```v---------v---- `R` is a union of Console | Logger```

Essentially, going from this:

![Sat Jul 15 09:30:47 PM CEST 2023](https://github.com/Effect-TS/website/assets/4209616/f64b2964-964d-41bc-a1e0-f8c8e9808254)

to this:

![Sat Jul 15 09:30:33 PM CEST 2023](https://github.com/Effect-TS/website/assets/4209616/51b4ba93-3de9-4323-b911-ae44579a73fd)
