### PR TITLE
Update `try.ts` example to use the `try` function

### DIFF
--- a/src/essentials/creating/try.ts
+++ b/src/essentials/creating/try.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 
 // $ExpectType Effect<never, never, number>
-const program = Effect.sync(() => {
+const program = Effect.try(() => {
   console.log("Hello, World!") // side effect
   return 42 // return value
 })

--- a/src/essentials/creating/try.ts
+++ b/src/essentials/creating/try.ts
@@ -1,7 +1,6 @@
 import { Effect } from "effect"
 
-// $ExpectType Effect<never, never, number>
-const program = Effect.try(() => {
-  console.log("Hello, World!") // side effect
-  return 42 // return value
-})
+// Effect<never, unknown, any>
+const program = Effect.try(
+  () => JSON.parse("") // JSON.parse may throw for bad input
+)


### PR DESCRIPTION
The code example for the simple use case of the `try` function uses the `sync` function. This fixes that.