### PR TITLE
fix Counter.ts in Ref guide

### DIFF
--- a/src/guide/state-management/Counter.ts
+++ b/src/guide/state-management/Counter.ts
@@ -1,18 +1,14 @@
 import { Effect, Ref } from "effect"
 
 export class Counter {
-  constructor(private value: Ref.Ref<number>) {}
+  inc: Effect.Effect<never, never, void>
+  dec: Effect.Effect<never, never, void>
+  get: Effect.Effect<never, never, number>
 
-  get inc() {
-    return Ref.update(this.value, (n) => n + 1)
-  }
-
-  get dec() {
-    return Ref.update(this.value, (n) => n - 1)
-  }
-
-  get get() {
-    return Ref.get(this.value)
+  constructor(private value: Ref.Ref<number>) {
+    this.inc = Ref.update(this.value, (n) => n + 1)
+    this.dec = Ref.update(this.value, (n) => n - 1)
+    this.get = Ref.get(this.value)
   }
 }
 

--- a/src/guide/state-management/Counter.ts
+++ b/src/guide/state-management/Counter.ts
@@ -2,9 +2,18 @@ import { Effect, Ref } from "effect"
 
 export class Counter {
   constructor(private value: Ref.Ref<number>) {}
-  inc = Ref.update(this.value, (n) => n + 1)
-  dec = Ref.update(this.value, (n) => n - 1)
-  get = Ref.get(this.value)
+
+  get inc() {
+    return Ref.update(this.value, (n) => n + 1)
+  }
+
+  get dec() {
+    return Ref.update(this.value, (n) => n - 1)
+  }
+
+  get get() {
+    return Ref.get(this.value)
+  }
 }
 
 // $ExpectType Effect<never, never, Counter>


### PR DESCRIPTION
Fixes the following issue running the code sample: 

```ts
node:internal/process/esm_loader:46
      internalBinding('errors').triggerUncaughtException(
                                ^

Error [TypeError]: Cannot read properties of undefined (reading 'modify')
TypeError: Cannot read properties of undefined (reading 'modify')
    at <anonymous> (/Users/erikshestopal/effect-ts-playground/node_modules/effect/node_modules/@effect/io/src/internal/ref.ts:119:52)
```