### PR TITLE
Fix fiber fork yieldNow example

### DIFF
--- a/src/guide/concurrency/fibers/fiber-fork-yieldNow.ts
+++ b/src/guide/concurrency/fibers/fiber-fork-yieldNow.ts
@@ -8,6 +8,7 @@ const program = Effect.gen(function* (_) {
     Stream.runDrain,
     Effect.fork
   )
+  yield* _(Effect.yieldNow())
   yield* _(SubscriptionRef.set(ref, 1))
   yield* _(SubscriptionRef.set(ref, 2))
 })


### PR DESCRIPTION
I accidentally forgot a line when moving the examples to their own files, oops!