### PR TITLE
fixed the line specification because it was incorrect

### DIFF
--- a/pages/docs/context-management/services.mdx
+++ b/pages/docs/context-management/services.mdx
@@ -80,7 +80,7 @@ We then use the `Console.log` utility to log the generated random number.
 </Tab>
 <Tab>
 
-```ts file=<rootDir>/src/guide/context-management/services/program-pipe.ts#L1-L8
+```ts file=<rootDir>/src/guide/context-management/services/program-pipe.ts#L1-L10
 
 ```
 
@@ -140,7 +140,7 @@ By calling `Effect.runSync(runnable){:ts}`, we execute the effect and observe th
 
 In the `program` definition, we have used the `Random` service only once:
 
-```ts /random.next()/ file=<rootDir>/src/guide/context-management/services/program-pipe.ts#L1-L8
+```ts /random.next()/ file=<rootDir>/src/guide/context-management/services/program-pipe.ts#L1-L10
 
 ```
 


### PR DESCRIPTION
Line references were out of alignment and have been corrected.

### before
<img width="528" alt="image" src="https://github.com/Effect-TS/website/assets/24796587/4572d4bc-9234-4b8b-8e0a-5a2071022398">


### after
<img width="517" alt="image" src="https://github.com/Effect-TS/website/assets/24796587/753a6df3-6e45-4f80-ab46-3e70fde53304">
