### PR TITLE
deferred example: use fork instead of runFork inside effects

### DIFF
--- a/src/concurrency/deferred/example.ts
+++ b/src/concurrency/deferred/example.ts
@@ -17,8 +17,8 @@ const program = Effect.gen(function* (_) {
   })
 
   // Run both fibers concurrently
-  const fiberA = Effect.runFork(sendHelloWorld)
-  const fiberB = Effect.runFork(getAndPrint)
+  const fiberA = yield* _(Effect.fork(sendHelloWorld))
+  const fiberB = yield* _(Effect.fork(getAndPrint))
 
   // Wait for both fibers to complete
   return yield* _(Fiber.join(Fiber.zip(fiberA, fiberB)))


### PR DESCRIPTION
[from discord](https://discord.com/channels/795981131316985866/1159519057045884928)

"runFork should not be used inside effects"