### PR TITLE
Remove non inclusive wording

### DIFF
--- a/pages/docs/error-management/fallback.mdx
+++ b/pages/docs/error-management/fallback.mdx
@@ -32,7 +32,7 @@ The `firstSuccessOf` operator simplifies running a series of effects and returns
 
 This operator utilizes `Effect.orElse` to combine multiple effects into a single effect.
 
-In the following example, we attempt to retrieve a configuration from different nodes. If retrieving from the master node fails, we successively try retrieving from the next available nodes until we find a successful result:
+In the following example, we attempt to retrieve a configuration from different nodes. If retrieving from the primary node fails, we successively try retrieving from the next available nodes until we find a successful result:
 
 ```ts file=<rootDir>/src/guide/error-management/fallback/firstSuccessOf.ts
 


### PR DESCRIPTION
This PR removes a reference to `master` from the docs

