### PR TITLE
Fix `TypeScript` casing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ const calSans = localFont({
 })
 
 export const metadata: Metadata = {
-  title: "Effect – The best way to build robust apps in Typescript",
+  title: "Effect – The best way to build robust apps in TypeScript",
   description:
     "Effect is a powerful TypeScript library designed to help developers easily create complex, synchronous, and asynchronous programs."
 }

--- a/src/components/sections/cta.tsx
+++ b/src/components/sections/cta.tsx
@@ -46,7 +46,7 @@ export const CTA = () => {
             </span>
             <br />
             <span className="text-transparent bg-clip-text bg-gradient-to-br from-white to-zinc-300">
-              in Typescript
+              in TypeScript
             </span>
           </h2>
           <p className="mt-8 mb-4 max-w-xl text-center mx-auto">

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -57,7 +57,7 @@ export const Hero = () => {
               </span>
               <br />
               <span className="text-transparent bg-clip-text bg-gradient-to-br from-white to-zinc-300">
-                in Typescript
+                in TypeScript
               </span>
             </h1>
             {/* <p className="mt-8 mb-4 max-w-md">

--- a/src/components/sections/screenshots.tsx
+++ b/src/components/sections/screenshots.tsx
@@ -23,7 +23,7 @@ const screenshots = [
     width: 1000,
     height: 633,
     heading: "Maximum Type-Safety",
-    text: "Effect leverages the full power of Typescript to give you confidence in your code. From errors to managing dependencies — if it compiles, it works."
+    text: "Effect leverages the full power of TypeScript to give you confidence in your code. From errors to managing dependencies — if it compiles, it works."
   },
   {
     src: "/images/screenshots/tracing.png",

--- a/src/components/sections/tweets.tsx
+++ b/src/components/sections/tweets.tsx
@@ -4,7 +4,7 @@ import Image from "next/image"
 
 const tweets = [
   {
-    text: `Effect is the 🐐 of Typescript
+    text: `Effect is the 🐐 of TypeScript
 
 - Rust style error handling
 - Retries, Concurrency, Steams, …


### PR DESCRIPTION
Replace all `Typescript` with `TypeScript`


- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
