### PR TITLE
Fix incorrect link to "the-effect-type"

### DIFF
--- a/content/docs/400-guides/100-essentials/100-importing-effect.mdx
+++ b/content/docs/400-guides/100-essentials/100-importing-effect.mdx
@@ -112,4 +112,4 @@ In the upcoming guides, we will explore some of these essential functions, speci
 
 But before we dive into those, let's start from the very heart of Effect: understanding the `Effect` type. This will lay the groundwork for your understanding of how Effect brings composability, type safety, and error handling into your applications.
 
-So, let's take the first step and explore the fundamental concepts of the [The Effect Type](effect-type).
+So, let's take the first step and explore the fundamental concepts of the [The Effect Type](the-effect-type).


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

The "Next ->" link at the bottom of the 
* https://effect.website/docs/guides/essentials/importing-effect 

page works and correctly points to 
* https://effect.website/docs/guides/essentials/the-effect-type

but the link in the text prior to this PR points to
* https://effect.website/docs/guides/essentials/effect-type

which gives a 404
