### PR TITLE
Fix order of Effect type parameters in building pipelines cheatsheet

### DIFF
--- a/content/docs/400-guides/100-essentials/600-pipeline.mdx
+++ b/content/docs/400-guides/100-essentials/600-pipeline.mdx
@@ -395,10 +395,10 @@ Let's summarize the transformation functions we have seen so far:
 
 | **Function** | **Input**                                 | **Output**                  |
 | ------------ | ----------------------------------------- | --------------------------- |
-| `map`        | `Effect<A, E, R>`, `A => B`               | `Effect<R, E, B>`           |
-| `flatMap`    | `Effect<A, E, R>`, `A => Effect<R, E, B>` | `Effect<R, E, B>`           |
-| `tap`        | `Effect<A, E, R>`, `A => Effect<R, E, B>` | `Effect<A, E, R>`           |
-| `all`        | `[Effect<A, E, R>, Effect<R, E, B>, ...]` | `Effect<R, E, [A, B, ...]>` |
+| `map`        | `Effect<A, E, R>`, `A => B`               | `Effect<B, E, R>`           |
+| `flatMap`    | `Effect<A, E, R>`, `A => Effect<B, E, R>` | `Effect<B, E, R>`           |
+| `tap`        | `Effect<A, E, R>`, `A => Effect<B, E, R>` | `Effect<A, E, R>`           |
+| `all`        | `[Effect<A, E, R>, Effect<B, E, R>, ...]` | `Effect<[A, B, ...], E, R>` |
 
 These functions are powerful tools for transforming and chaining `Effect` computations. They allow you to apply functions to values inside `Effect` and build complex pipelines of computations.
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Currently, in the [building pipelines cheatsheet](https://effect.website/docs/guides/essentials/pipeline#cheatsheet), some `Effect` type parameters have reversed order. This PR fixes that, making the order of the type parameters in sync with the latest `Effect` type.

