### PR TITLE
Fix order of type parameters in "Coming from ZIO" page

### DIFF
--- a/content/docs/700-other/700-coming-from-zio.mdx
+++ b/content/docs/700-other/700-coming-from-zio.mdx
@@ -13,8 +13,8 @@ In Effect, we represent the environment required to run an `Effect` workflow as 
 ```ts twoslash
 import { Effect } from "effect"
 
-//                           v---------v---- `R` is a union of Console | Logger
-type Http = Effect.Effect<Console | Logger, IOError | HttpError, Response>
+//                                                          v---------v---- `R` is a union of Console | Logger
+type Http = Effect.Effect<Response, IOError | HttpError, Console | Logger>
 
 type Response = Record<string, string>
 


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
The sample code from "Coming from ZIO" has the old `Effect<R, E, A>` type, this change align it to `Effect<A, E, R>`

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
