### PR TITLE
Fix uneeded "and" in blog post authors when there is only one author

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -55,7 +55,7 @@ export default function Blog() {
                     <span>By </span>
                     {authors.map(({ name }, index) => (
                       <>
-                        {index === authors.length - 1 && <span>and </span>}
+                        {authors.length !== 1 && index === authors.length - 1 && <span>and </span>}
                         {index > 0 && index < authors.length - 1 && (
                           <span>, </span>
                         )}


### PR DESCRIPTION
saw this during mike's talk and it kinda bothered me so I had to fix it

before:

![image](https://github.com/Effect-TS/website/assets/100045248/bf02c27f-9494-4337-b222-866ccafc61b7)


after:

(should be fixed but I could not get next to run locally, dev mode or build, so dont know for sure)