### PR TITLE
fix(grammar): fixed wrong grammar in expected error section

### DIFF
--- a/content/docs/400-guides/150-error-management/200-expected-errors.mdx
+++ b/content/docs/400-guides/150-error-management/200-expected-errors.mdx
@@ -300,7 +300,7 @@ const recovered = program.pipe(
 </Tabs>
 
 We can observe that the type in the error channel of our program has changed to `never`,
-indicating that all errors has been handled.
+indicating that all errors have been handled.
 
 ```ts
 Effect<string>
@@ -370,7 +370,7 @@ const recovered = Effect.gen(function* (_) {
 ```
 
 We can observe that the type in the error channel of our program has changed to `never`,
-indicating that all errors has been handled.
+indicating that all errors have been handled.
 
 </Tab>
 <Tab>
@@ -451,7 +451,7 @@ const recovered = program.pipe(
 ```
 
 We can observe that the type in the error channel of our program has changed to `never`,
-indicating that all errors has been handled.
+indicating that all errors have been handled.
 
 <Warning>
   It is important to ensure that the error type used with `catchTag` has a


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Fixed a small grammar error observed in the expected error section of the documentation
