### PR TITLE
Fix grammar in the Effect type section

### DIFF
--- a/content/docs/400-guides/100-essentials/200-the-effect-type.mdx
+++ b/content/docs/400-guides/100-essentials/200-the-effect-type.mdx
@@ -7,7 +7,7 @@ bottomNavigation: pagination
 The `Effect<Success, Error, Requirements>` type represents an **immutable** value that **lazily** describes a workflow or job.
 
 It encapsulates the logic of a program that requires a collection of contextual data `Context<Requirements>` to execute.
-This program can either fail, produce an error of type `Error`, or succeed, yielding a value of type `Value`.
+This program can either fail, producing an error of type `Error`, or succeed, yielding a value of type `Value`.
 
 Conceptually, you can think of `Effect<Success, Error, Requirements>` as an effectful version of the following function type:
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This PR fixes a grammar issue in the Effect type section.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->