### PR TITLE
Fix: duplicate heading slugs

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -9,6 +9,7 @@ import rehypeRaw from "rehype-raw"
 import { nodeTypes } from "@mdx-js/mdx"
 import codeImport from "remark-code-import"
 import remarkMdxCodeMeta from "remark-mdx-code-meta"
+import rehypeSlug from "rehype-slug"
 
 export const CODE_BLOCK_FILENAME_REGEX = /filename="([^"]+)"/
 
@@ -38,8 +39,11 @@ export default makeSource({
   mdx: {
     remarkPlugins: [
       [codeImport as any, { rootDir: process.cwd() + "/content" }],
-      // @ts-expect-error
-      [remarkShikiTwoslash.default, { themes: ["github-dark", "github-light"] }],
+      [
+        // @ts-expect-error
+        remarkShikiTwoslash.default,
+        { themes: ["github-dark", "github-light"] }
+      ],
       // [conditionalShikiTwoslash, { theme: "github-dark" }],
       remarkGfm,
       remarkMdxCodeMeta
@@ -49,7 +53,8 @@ export default makeSource({
       [
         rehypePrettyCode,
         { ...DEFAULT_REHYPE_PRETTY_CODE_OPTIONS, theme: "github-dark" }
-      ] as any
+      ] as any,
+      [rehypeSlug]
     ]
   }
 })

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "^18",
     "react-instantsearch": "^7.4.1",
     "react-tweet": "^3.2.0",
+    "rehype-slug": "^6.0.0",
     "remark-mdx-code-meta": "^2.0.0",
     "shikiji": "^0.8.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ dependencies:
   react-tweet:
     specifier: ^3.2.0
     version: 3.2.0(react-dom@18.2.0)(react@18.2.0)
+  rehype-slug:
+    specifier: ^6.0.0
+    version: 6.0.0
   remark-mdx-code-meta:
     specifier: ^2.0.0
     version: 2.0.0
@@ -4487,6 +4490,10 @@ packages:
       resolve-pkg-maps: 1.0.0
     dev: true
 
+  /github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+    dev: false
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4671,6 +4678,12 @@ packages:
       vfile-location: 5.0.2
       web-namespaces: 2.0.1
 
+  /hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+    dependencies:
+      '@types/hast': 3.0.3
+    dev: false
+
   /hast-util-parse-selector@3.1.1:
     resolution: {integrity: sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==}
     dependencies:
@@ -4796,7 +4809,6 @@ packages:
     resolution: {integrity: sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==}
     dependencies:
       '@types/hast': 3.0.3
-    dev: true
 
   /hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
@@ -7108,6 +7120,16 @@ packages:
       hast-util-raw: 7.2.3
       unified: 10.1.2
     dev: true
+
+  /rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+    dependencies:
+      '@types/hast': 3.0.3
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.0
+      unist-util-visit: 5.0.0
+    dev: false
 
   /rehype-stringify@9.0.4:
     resolution: {integrity: sha512-Uk5xu1YKdqobe5XpSskwPvo1XeHUUucWEQSl8hTrXt5selvca1e8K1EZ37E6YoZ4BT8BCqCdVfQW7OfHfthtVQ==}

--- a/src/components/atoms/headings.tsx
+++ b/src/components/atoms/headings.tsx
@@ -1,32 +1,59 @@
 "use client"
 
-import { sluggifyTitle, getNodeText } from "@/contentlayer/utils/sluggify"
+import { getNodeText } from "@/contentlayer/utils/sluggify"
 
-export const H2: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
-  const slug = sluggifyTitle(getNodeText(children))
+export const H2: React.FC<React.PropsWithChildren<{ id?: string }>> = ({
+  id,
+  children
+}) => {
+  // const slug = slugs.slug(getNodeText(children))
   return (
-    <h2 id={slug} onClick={() => (window.location.hash = `#${slug}`)} className="group cursor-pointer">
-      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">#</span>
+    <h2
+      id={id}
+      onClick={() => (window.location.hash = `#${id}`)}
+      className="group cursor-pointer"
+    >
+      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">
+        #
+      </span>
       {children}
     </h2>
   )
 }
 
-export const H3: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
-  const slug = sluggifyTitle(getNodeText(children))
+export const H3: React.FC<React.PropsWithChildren<{ id?: string }>> = ({
+  id,
+  children
+}) => {
+  // const slug = slugs.slug(getNodeText(children))
   return (
-    <h3 id={slug} onClick={() => (window.location.hash = `#${slug}`)} className="group cursor-pointer">
-      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">#</span>
+    <h3
+      id={id}
+      onClick={() => (window.location.hash = `#${id}`)}
+      className="group cursor-pointer"
+    >
+      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">
+        #
+      </span>
       {children}
     </h3>
   )
 }
 
-export const H4: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
-  const slug = sluggifyTitle(getNodeText(children))
+export const H4: React.FC<React.PropsWithChildren<{ id?: string }>> = ({
+  id,
+  children
+}) => {
+  // const slug = slugs.slug(getNodeText(children))
   return (
-    <h4 id={slug} onClick={() => (window.location.hash = `#${slug}`)} className="group cursor-pointer">
-      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">#</span>
+    <h4
+      id={id}
+      onClick={() => (window.location.hash = `#${id}`)}
+      className="group cursor-pointer"
+    >
+      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">
+        #
+      </span>
       {children}
     </h4>
   )

--- a/src/components/atoms/mdx.tsx
+++ b/src/components/atoms/mdx.tsx
@@ -17,7 +17,6 @@ const YouTube = ({ url }: { url: string }) => (
       className="video-responsive-iframe"
       src={url}
       title="YouTube video player"
-      frameBorder="0"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowFullScreen
     />

--- a/src/components/docs/navigation-link.tsx
+++ b/src/components/docs/navigation-link.tsx
@@ -68,20 +68,21 @@ export const NavigationLink: FC<{
           {element.title}
         </span>
         {element.children.length > 0 && element.collapsible && (
-          <button
-            className="h-5 w-5 flex items-center justify-center"
-            onClick={(e) => {
-              e.preventDefault()
-              setCollapsed((collapsed) => !collapsed)
-            }}
-          >
-            <Icon
-              name="chevron-right"
-              className={`h-3 -mt-0.5 transition-transform duration-200 ${
-                collapsed ? "rotate-0" : "rotate-90"
-              }`}
-            />
-          </button>
+          // <button
+          //   className="relative h-5 w-5 flex items-center justify-center"
+          //   onClick={(e) => {
+          //     e.preventDefault()
+          //     console.log(collapsed)
+          //     setCollapsed((collapsed) => !collapsed)
+          //   }}
+          // >
+          <Icon
+            name="chevron-right"
+            className={`h-3 -mt-0.5 transition-transform duration-200 ${
+              collapsed ? "rotate-0" : "rotate-90"
+            }`}
+          />
+          // </button>
         )}
       </Link>
       {element.children && !collapsed && (

--- a/src/components/docs/table-of-contents.tsx
+++ b/src/components/docs/table-of-contents.tsx
@@ -1,25 +1,23 @@
 "use client"
 
-import { getNodeText, sluggifyTitle } from "@/contentlayer/utils/sluggify"
 import Link from "next/link"
 import { FC, useEffect, useState } from "react"
 import { Icon } from "../icons"
 import { Divider } from "../layout/divider"
 
 export const TableOfContents: FC<{
-  elements: { level: number; title: string }[]
+  elements: DocHeading[]
   pageFilePath?: string
   pageTitle?: string
 }> = ({ elements, pageFilePath, pageTitle }) => {
   const [activeHeading, setActiveHeading] = useState("")
   const [showScrollToTopButton, setShowScrollToTopButton] =
     useState<boolean>(false)
-
+  console.log(elements)
   useEffect(() => {
     const handleScroll = () => {
       let current = ""
-      for (const { title } of elements) {
-        const slug = sluggifyTitle(getNodeText(title))
+      for (const { title, slug } of elements) {
         const element = document.getElementById(slug)
         if (element && element.getBoundingClientRect().top < 256)
           current = slug
@@ -53,8 +51,7 @@ export const TableOfContents: FC<{
         <ul className="relative grow overflow-y-auto py-9 text-sm">
           {elements
             .slice(1, elements.length)
-            .map(({ level, title }, index) => {
-              const slug = sluggifyTitle(getNodeText(title))
+            .map(({ level, title, slug }, index) => {
               return (
                 <li
                   key={index}

--- a/src/contentlayer/utils/toc-plugin.ts
+++ b/src/contentlayer/utils/toc-plugin.ts
@@ -1,35 +1,22 @@
-import type * as unified from 'unified'
-import {toMarkdown} from 'mdast-util-to-markdown'
-import {mdxToMarkdown} from 'mdast-util-mdx'
+import type * as unified from "unified"
+import GithubSlugger from "github-slugger"
+import { toString } from "hast-util-to-string"
+
+const slugger = new GithubSlugger()
 
 export const tocPlugin =
   (headings: DocHeading[]): unified.Plugin =>
   () => {
     return (node: any) => {
-      for (const element of node.children.filter((_: any) => _.type === 'heading' || _.name === 'OptionsTable')) {
-        if (element.type === 'heading') {
-          const title = toMarkdown({type: 'paragraph', children: element.children}, {extensions: [mdxToMarkdown()]})
-            .trim()
-            .replace(/<.*$/g, '')
-            .replace(/\\/g, '')
-            .trim()
-          headings.push({level: element.depth, title})
-        } else if (element.name === 'OptionsTable') {
-          element.children
-            .filter((_: any) => _.name === 'OptionTitle')
-            .forEach((optionTitle: any) => {
-              optionTitle.children
-                .filter((_: any) => _.type === 'heading')
-                .forEach((heading: any) => {
-                  const title = toMarkdown({type: 'paragraph', children: heading.children}, {extensions: [mdxToMarkdown()]})
-                    .trim()
-                    .replace(/<.*$/g, '')
-                    .replace(/\\/g, '')
-                    .trim()
-                  headings.push({level: heading.depth, title})
-                })
-            })
-        }
+      for (const element of node.children.filter(
+        (element: any) => element.type === "heading"
+      )) {
+        const title = toString(element)
+        headings.push({
+          level: element.depth,
+          title,
+          slug: slugger.slug(title)
+        })
       }
     }
   }

--- a/src/types/doc-heading.d.ts
+++ b/src/types/doc-heading.d.ts
@@ -1,1 +1,1 @@
-type DocHeading = {level: 1 | 2 | 3; title: string}
+type DocHeading = { level: 1 | 2 | 3; title: string; slug: string }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Now using rehype-slug and github-slugger to generate the heading slugs, adding a number to duplicate ids.
Example: #schema and #schema-1.

Also updated the docs nav so that a collapsed nav item also expands when clicking the chevron icon.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
