### PR TITLE
Fix grammar issue in Resource Management example comment

### DIFF
--- a/content/docs/400-guides/250-resource-management.mdx
+++ b/content/docs/400-guides/250-resource-management.mdx
@@ -863,7 +863,7 @@ import * as Workspace from "./Workspace"
 
 // The `FailureCaseLiterals` type allows us to provide different error scenarios while testing our services.
 // For example, by providing the value "S3", we can simulate an error scenario specific to the S3 service.
-// This helps us ensure that our program handle errors correctly and behave as expected in various situations.
+// This helps us ensure that our program handles errors correctly and behaves as expected in various situations.
 // Similarly, we can provide other values like "ElasticSearch" or "Database" to simulate error scenarios for those services.
 // In cases where we want to test the absence of errors, we can provide `undefined`.
 // By using this parameter, we can thoroughly test our services and verify their behavior under different error conditions.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

In the code example provided in the [Resource Management](https://effect.website/docs/guides/resource-management#pattern-sequence-of-operations-with-compensating-actions-on-failure) guide, there is a grammar issue in a comment, where verbs should be in singular third-person since the subject of the sentence is "program".


<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
