### PR TITLE
Updated wrong/confusing example-code talk through

### DIFF
--- a/content/docs/200-why-effect.mdx
+++ b/content/docs/200-why-effect.mdx
@@ -38,13 +38,13 @@ Here's the same divide function from above, but with the Effect pattern:
 ```ts twoslash
 import { Effect } from "effect"
 
-const divide = (a: number, b: number): Effect.Effect<number, Error> =>
+const divide = (a: number, b: number): Effect.Effect<number, Error, never> =>
   b === 0
     ? Effect.fail(new Error("Cannot divide by zero"))
     : Effect.succeed(a / b)
 ```
 
-Notice how looking at the type signature tells you exactly what context the function needs (`never`, as in, no context required here), what error(s) it can throw (`Error`), and what success value(s) it returns (`number`). This function no longer throws an exception, and you can cleanly pass on the error to the caller of this function.
+Notice how looking at the type signature tells you exactly what success value(s) it returns (`number`), what error(s) it can throw (`Error`) and what context the function needs (`never`, as in, no context required here). This function no longer throws an exception, and you can cleanly pass on the error to the caller of this function.
 
 Errors now become values, just like your success values. Effect gives us many functions to make managing errors and success values ergonomic.
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
Just noticed this confusing example, when checking the project out. I'm pretty sure it's because of a change in the effect type from some time ago.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
