### PR TITLE
Fix typo in Logging guide (LoggerLevel -> LogLevel)

### DIFF
--- a/content/docs/400-guides/400-observability/100-logging.mdx
+++ b/content/docs/400-guides/400-observability/100-logging.mdx
@@ -52,7 +52,7 @@ The log message contains the following information:
 
 By default, `DEBUG` messages are **not** printed.
 
-However, you can configure the default logger to enable them using `Logger.withMinimumLogLevel` and setting the minimum log level to `LoggerLevel.Debug`.
+However, you can configure the default logger to enable them using `Logger.withMinimumLogLevel` and setting the minimum log level to `LogLevel.Debug`.
 
 Here's an example that demonstrates how to enable `DEBUG` messages for a specific task (`task1`):
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

In the [Logging](https://effect.website/docs/guides/observability/logging) guide, there's a small typo related to setting the log level. `LoggerLevel.Debug` should be `LogLevel.Debug`. 


<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
