### PR TITLE
Remove duplicate title in Introduction to Telemetry

### DIFF
--- a/content/docs/400-guides/400-observability/400-telemetry/100-intro.mdx
+++ b/content/docs/400-guides/400-observability/400-telemetry/100-intro.mdx
@@ -5,8 +5,6 @@ excerpt: Explore the seamless integration of Telemetry in Effect, providing insi
 bottomNavigation: pagination
 ---
 
-# Introduction to Telemetry in Effect
-
 Telemetry enables developers to collect, process, and export telemetry data such as [metrics](metrics) and [traces](tracing), providing valuable insights into the performance and behavior of their applications. In this guide, we will explore how Telemetry can be seamlessly integrated into Effect.
 
 By incorporating Telemetry, you can gain deep visibility into the inner workings of your TypeScript applications, effortlessly tracing the flow of requests, pinpointing bottlenecks, and identifying performance optimizations. This integration empowers you to monitor, analyze, and improve your application's reliability and efficiency, ensuring a better user experience.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Currently, in the [Introduction to Telemetry in Effect](https://effect.website/docs/guides/observability/telemetry/intro), a duplicate title is shown:

![Screenshot 2024-03-30 at 18 40 08](https://github.com/Effect-TS/website/assets/65446569/ff2ce38c-fcc9-445e-a36b-5f97c3e17d98)

This is because the title is specified both in the front matter and in a heading. This PR removes the unnecessary heading.

