### PR TITLE
Remove unnecessary line highlights in Tracing examples

### DIFF
--- a/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
+++ b/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
@@ -61,7 +61,7 @@ Now, let's print our Span to the console. To achieve this, we need specific tool
 
 Here's a code snippet demonstrating how to set up the necessary environment and print the Span to the console:
 
-```ts {23} twoslash
+```ts twoslash
 import { Effect } from "effect"
 import { NodeSdk } from "@effect/opentelemetry"
 import {
@@ -115,7 +115,7 @@ Here's a breakdown of the output:
 
 Let's examine the output of an effect that encountered an error:
 
-```ts {33} twoslash
+```ts twoslash
 import { Effect } from "effect"
 import { NodeSdk } from "@effect/opentelemetry"
 import {
@@ -165,7 +165,7 @@ Example Output:
 You can provide extra information to a span by utilizing the `Effect.annotateCurrentSpan` function.
 This tool allows you to associate key-value pairs, offering more context about the execution of the span.
 
-```ts {30} twoslash
+```ts twoslash
 import { Effect } from "effect"
 import { NodeSdk } from "@effect/opentelemetry"
 import {
@@ -208,7 +208,7 @@ Example Output:
 
 Logs are transformed into what are known as "Span Events." These events provide structured information and a timeline of occurrences within your application.
 
-```ts {31-38} twoslash
+```ts twoslash
 import { Effect } from "effect"
 import { NodeSdk } from "@effect/opentelemetry"
 import {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

In the [Tracing](https://effect.website/docs/guides/observability/telemetry/tracing) guide, code examples have unnecessary line highlights, which do not seem relevant to what's being said (apart from the last example, see below for details) but only add distractions that make the code examples harder to read.

Here are the screenshots with the current highlights:

## Printing Spans

![image](https://github.com/Effect-TS/website/assets/65446569/c94e1c59-8888-426d-ba0c-6584ebf79591)

## Printing Spans (error example)

![image](https://github.com/Effect-TS/website/assets/65446569/8494df95-a7b1-432a-a08c-dc6ecf2a9a2c)

## Adding Annotations

![image](https://github.com/Effect-TS/website/assets/65446569/1b0507b1-fb63-41ed-a4e3-582970fc8769)

## Logs as events

![image](https://github.com/Effect-TS/website/assets/65446569/d314e9fc-ea5e-47eb-abc7-34a426813108)

Now, this last example highlights the events part in the payload (excluding the closing square bracket), but also highlights the `status`, which does not seem relevant to the example. So, we could shift the highlight 1 line down so that the `status` is not highlighted but the closing bracket is. However, considering that this example uses `Effect.log`, we probably should highlight that part too. However, I do not see much benefit in highlighting lines in this example, so I kept it consistent with all the other examples, which don't have anything highlighted. Let me know if you prefer doing otherwise. 


<!--
Please add a brief summary/description of the pull request here.
-->

