### PR TITLE
Add missing backticks around inline code in Tracing guide

### DIFF
--- a/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
+++ b/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
@@ -253,7 +253,7 @@ Example Output:
 */
 ```
 
-Spans can contain events, which are records of specific moments during the span's lifecycle. In this output, there is one event named 'Hello.' It includes associated attributes, such as 'effect.fiberId' and 'effect.logLevel,' providing information about the logged event. The 'time' field represents the timestamp when the event occurred.
+Spans can contain events, which are records of specific moments during the span's lifecycle. In this output, there is one event named `'Hello'`. It includes associated attributes, such as `'effect.fiberId'` and `'effect.logLevel'`, providing information about the logged event. The `time` field represents the timestamp when the event occurred.
 
 ## Nesting Spans
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

In the [Tracing](https://effect.website/docs/guides/observability/telemetry/tracing) guide, when talking about span events, backticks are missing around inline code. This PR adds them.