### PR TITLE
fix: complexity Code width/overflow on mobile

### DIFF
--- a/src/components/sections/complexity.tsx
+++ b/src/components/sections/complexity.tsx
@@ -158,7 +158,7 @@ export const Complexity = () => {
             </ul>
           </div>
         </div>
-        <div className="grid lg:grid-cols-2 gap-y-12 gap-x-6 pt-12">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-y-12 gap-x-6 pt-12">
           <div className="flex flex-col items-center gap-6">
             <h3 className="font-display text-2xl text-white">
               Without Effect


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On mobile the `<Code/>`  components within `complexity.tsx` overflowed and did not scroll horizontally. The heading text above was also not centred. See screenshots below (before/after):

<img width="313" alt="Screenshot 2024-04-04 at 4 28 48 pm" src="https://github.com/Effect-TS/website/assets/32081962/5d0ad3f9-ba29-41d5-8902-61297bdbdc8d">

<img width="310" alt="Screenshot 2024-04-04 at 4 38 27 pm" src="https://github.com/Effect-TS/website/assets/32081962/8247312d-b6c2-4b6e-8c76-aecef6d67ad1">




