### PR TITLE
Fix list of required dependencies for the example that simulates traces

### DIFF
--- a/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
+++ b/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
@@ -364,6 +364,8 @@ Now, let's simulate traces using a sample Node.js application. We'll provide you
 
    - `@effect/opentelemetry`
    - `@opentelemetry/exporter-trace-otlp-http`
+   - `@opentelemetry/sdk-trace-node`
+   - `@opentelemetry/sdk-trace-web`
 
    ```ts twoslash
    import { Effect } from "effect"


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

In the [Introduction to Tracing in Effect](https://effect.website/docs/guides/observability/telemetry/tracing) guide, the list of dependencies required to run the [example that simulates traces](https://effect.website/docs/guides/observability/telemetry/tracing#simulating-traces) is missing two dependencies: `@opentelemetry/sdk-trace-node` and `@opentelemetry/sdk-trace-web`. Without those, running the example breaks:

```
Error: Cannot find module '@opentelemetry/sdk-trace-node'
Require stack:
- ./node_modules/@effect/opentelemetry/dist/cjs/NodeSdk.js
- ./node_modules/@effect/opentelemetry/dist/cjs/index.js
```

```
Error: Cannot find module '@opentelemetry/sdk-trace-web'
Require stack:
- ./node_modules/@effect/opentelemetry/dist/cjs/WebSdk.js
- ./node_modules/@effect/opentelemetry/dist/cjs/index.js
```
