### PR TITLE
Fix type of PORT config in Configuration example

### DIFF
--- a/content/docs/400-guides/450-configuration.mdx
+++ b/content/docs/400-guides/450-configuration.mdx
@@ -32,7 +32,7 @@ import { Effect, Config } from "effect"
 
 const program = Effect.gen(function* (_) {
   const host = yield* _(Config.string("HOST"))
-  const port = yield* _(Config.string("PORT"))
+  const port = yield* _(Config.number("PORT"))
   console.log(`Application started: ${host}:${port}`)
 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

In the [Configuration](https://effect.website/docs/guides/configuration) guide, the `PORT` config has type `number` across all examples except for one, where it is typed as `string`. This PR fixes that.