### PR TITLE
chore: avoid "a synchronous" wording and fix spelling

### DIFF
--- a/content/blog/0001-this-week-in-effect-2024-02-02.mdx
+++ b/content/blog/0001-this-week-in-effect-2024-02-02.mdx
@@ -126,7 +126,7 @@ Adds a new section to the project README that explains the annotations feature b
 
 Reorganizes overloads in `Schema.optional` to improve development experience when specifying defaults.
 
-- [Fix Equivalence with Transormations](https://github.com/Effect-TS/effect/pull/2017)
+- [Fix Equivalence with Transformations](https://github.com/Effect-TS/effect/pull/2017)
 
 Improves generation of `Equivalence` supporting cases where schemas include transformations. Namely the following code:
 
@@ -141,7 +141,7 @@ No longer throws an error.
 
 - [Add option to preserve excess properties](https://github.com/Effect-TS/effect/pull/2011)
 
-Add `option` to preserve excess properties when parsing, the feature is described in detail in [the issue](https://github.com/Effect-TS/effect/issues/2008) and can be summerized as:
+Add `option` to preserve excess properties when parsing, the feature is described in detail in [the issue](https://github.com/Effect-TS/effect/issues/2008) and can be summarized as:
 
 ```ts
 const data = S.parseSync({
@@ -261,7 +261,7 @@ Ensuring that fibers forked in uninterruptible regions are able to be interrupte
 
 - [Fix error reporting for single input](https://github.com/Effect-TS/effect/pull/2001)
 
-Ensures proper error reporting when a single input is provided to a variadic option. Priorly, the check was silently skipped.
+Ensures proper error reporting when a single input is provided to a variadic option. Prior, the check was silently skipped.
 
 - [Update README](https://github.com/Effect-TS/effect/pull/2003)
 

--- a/content/blog/0005-this-week-in-effect-2024-02-16.mdx
+++ b/content/blog/0005-this-week-in-effect-2024-02-16.mdx
@@ -88,7 +88,7 @@ Big news of the week: **Effect 2.3 has been released!** Read the release post [h
 + [Add Runtime.updateFiberRefs/setFiberRef/deleteFiberRef](https://github.com/Effect-TS/effect/pull/2149)
 + [Expose ModuleVersion](https://github.com/Effect-TS/effect/pull/2142)
 + [Avoid incrementing cache hits for expired entries](https://github.com/Effect-TS/effect/pull/2159)
-+ [Fix Hash implemention for Option.none](https://github.com/Effect-TS/effect/pull/2165)
++ [Fix Hash implementation for Option.none](https://github.com/Effect-TS/effect/pull/2165)
 
 ### Effect Schema
 + [Change MessageAnnotation to be non parametric](https://github.com/Effect-TS/effect/pull/2170)

--- a/content/blog/0009-this-week-in-effect-2024-03-15.mdx
+++ b/content/blog/0009-this-week-in-effect-2024-03-15.mdx
@@ -69,7 +69,7 @@ Below you may find the list of all changes that occurred last week.
 
 ### Effect Platform
 + [Add WebSocket support to /platform http server](https://github.com/Effect-TS/effect/pull/2261) (Feature, next-minor)
-+ [Propogate Socket handler errors to .run Effect](https://github.com/Effect-TS/effect/pull/2267) (Feature, next-minor)
++ [Propagate Socket handler errors to .run Effect](https://github.com/Effect-TS/effect/pull/2267) (Feature, next-minor)
 + [Add PlatformLogger module](https://github.com/Effect-TS/effect/pull/2269) (Feature, next-minor)
 + [Remove log.txt](https://github.com/Effect-TS/effect/pull/2272) (Documentation Update, next-minor)
 + [Fix /platform docgen](https://github.com/Effect-TS/effect/pull/2272) (Bug Fix, next-minor)

--- a/content/blog/0014-this-week-in-effect-2024-04-05.mdx
+++ b/content/blog/0014-this-week-in-effect-2024-04-05.mdx
@@ -75,7 +75,7 @@ Below you may find the list of all changes that occurred last week.
 + [Move non-streaming rpc apis to separate module](https://github.com/Effect-TS/effect/pull/2455) (Refactor)
 + [Replace use of unit terminology with void](https://github.com/Effect-TS/effect/pull/2476) (Refactor, next-minor)
 
-### Evvect Vitest
+### Effect Vitest
 + [Replace use of unit terminology with void](https://github.com/Effect-TS/effect/pull/2476) (Refactor, next-minor)
 
 

--- a/content/docs/400-guides/100-essentials/300-creating-effects.mdx
+++ b/content/docs/400-guides/100-essentials/300-creating-effects.mdx
@@ -73,7 +73,7 @@ In this example, the `divide` function explicitly indicates that it can produce 
 
 ## Modeling Synchronous Effects
 
-In JavaScript, you can delay the execution of a synchronous computation using a "thunk".
+In JavaScript, you can delay the execution of synchronous computations using "thunks".
 
 <Info>
   A "thunk" is a function that takes no arguments and may return some value.

--- a/content/docs/700-other/700-coming-from-zio.mdx
+++ b/content/docs/700-other/700-coming-from-zio.mdx
@@ -66,7 +66,7 @@ In previous versions of Effect, intersections were used for representing an envi
 
 In ZIO 2.0, the _contravariant_ `R` type parameter of the `ZIO` type (representing the environment) became fully phantom, thus allowing for removal of the `Has` type. This significantly improved the clarity of type signatures as well as removing another "stumbling block" for new users.
 
-To faciliate removal of `Has` in Effect, we had to consider how types in the environment compose. By the rule of composition, contravariant parameters composed as an intersection (i.e. with `&`) are equivalent to covariant parameters composed together as a union (i.e. with `|`) for purposes of assignability. Based upon this fact, we decided to diverge from ZIO and make the `R` type parameter _covariant_ given `A | B` does not reduce to `never` if `A` and `B` have conflicts.
+To facilitate removal of `Has` in Effect, we had to consider how types in the environment compose. By the rule of composition, contravariant parameters composed as an intersection (i.e. with `&`) are equivalent to covariant parameters composed together as a union (i.e. with `|`) for purposes of assignability. Based upon this fact, we decided to diverge from ZIO and make the `R` type parameter _covariant_ given `A | B` does not reduce to `never` if `A` and `B` have conflicts.
 
 From our example above:
 


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

avoid "a synchronous" wording and fix a few spelling errors

