### PR TITLE
UI  - Fix Search Input autofocus on Safari

### DIFF
--- a/src/components/atoms/search.tsx
+++ b/src/components/atoms/search.tsx
@@ -39,7 +39,7 @@ export const Search: FC<{ className?: string }> = ({ className = "" }) => {
       setTimeout(
         //@ts-ignore
         () => document.querySelector(".ais-SearchBox-input")?.focus(),
-        1
+        100
       )
     } else {
       document.body.classList.remove("no-scroll")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

### Bug:
On Safari, the "cmd + k" keyboard shortcut opens the Search Dialog, but the input field doesn't get focused as expected. Other Chromium-based browsers do not suffer the same issue.

https://github.com/Effect-TS/website/assets/15946771/2d070737-026c-4b3b-90e4-8c5bc1edda44


 
### Issue:
The query selector used to grab the search box element from the DOM had a `setTimeout` set to **1ms**.

### Fix:  
Tentatively increased said `setTimeout` to **100ms** . This does the trick.
A possible alternative solution could be to use the `React.useRef` API instead on the `SearchBox` component.


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
