### PR TITLE
Close mobile menu on same-page navigation

### DIFF
--- a/src/components/layout/mobile-menu.tsx
+++ b/src/components/layout/mobile-menu.tsx
@@ -21,8 +21,10 @@ export const MobileMenu: FC<{
     }
   }, [open])
 
+  const closeMenu = () => setOpen(false);
+
   useEffect(() => {
-    setOpen(false)
+    closeMenu();
   }, [pathname])
 
   return (
@@ -43,6 +45,7 @@ export const MobileMenu: FC<{
               key={index}
               href={href}
               className="flex items-start text-black dark:text-white"
+              onClick={() => closeMenu()}
             >
               <span>{name}</span>
               {href.startsWith("http") && (


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
When viewing the website on a mobile device, navigating to the current page from the nav menu didn’t cause the nav menu to close, even though it did cause a page scroll. For example, when I’m on the docs page and I click the docs link.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #596
- Closes #596
