### PR TITLE
Improve Quickstart/Node.js ts-node command

### DIFF
--- a/content/docs/300-quickstart.mdx
+++ b/content/docs/300-quickstart.mdx
@@ -72,10 +72,10 @@ const program = Console.log("Hello, World!")
 Effect.runSync(program)
 ```
 
-Run the `index.ts` file. If you have [`ts-node`](https://github.com/TypeStrong/ts-node) installed, run the following command in the terminal:
+Run the `index.ts` file. Here we are using [`ts-node`](https://github.com/TypeStrong/ts-node) to run the `index.ts` file in the terminal:
 
 ```bash filename="Terminal"
-ts-node src/index.ts
+npx ts-node src/index.ts
 ```
 
 You should see the message `"Hello, World!"` printed. This confirms that the program is working correctly.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Previously in order to run the [Quickstart Node.js](https://effect.website/docs/quickstart) guide, the assumption was that the user is already installed `ts-node` globally. I updated the command and used `npx` (which comes out of the box with installing node) so we don't need to worry about that assumption, and users can run the `index.ts` file and see the output faster and easier.

