### PR TITLE
Fix incorrect syntax for Generator

### DIFF
--- a/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
+++ b/content/docs/400-guides/400-observability/400-telemetry/300-tracing.mdx
@@ -280,10 +280,10 @@ const child = Effect.void.pipe(
   Effect.withSpan("child")
 )
 
-const parent = Effect.gen(function* () {
-  yield* Effect.sleep("20 millis")
-  yield* child
-  yield* Effect.sleep("10 millis")
+const parent = Effect.gen(function* (_) {
+  yield* _(Effect.sleep("20 millis"))
+  yield* _(child)
+  yield* _(Effect.sleep("10 millis"))
 }).pipe(Effect.withSpan("parent"))
 
 const NodeSdkLive = NodeSdk.layer(() => ({
@@ -387,13 +387,15 @@ Now, let's simulate traces using a sample Node.js application. We'll provide you
      delay: number,
      children: ReadonlyArray<Effect.Effect<void>> = []
    ) =>
-     Effect.gen(function* () {
-       yield* Effect.log(name)
-       yield* Effect.sleep(`${delay} millis`)
+     Effect.gen(function* (_) {
+       yield* _(Effect.log(name))
+       yield* _(Effect.sleep(`${delay} millis`))
+
        for (const child of children) {
-         yield* child
+        yield* _(child)
        }
-       yield* Effect.sleep(`${delay} millis`)
+
+       yield* _(Effect.sleep(`${delay} millis`))
      }).pipe(Effect.withSpan(name))
 
    const poll = task("/poll", 1)


### PR DESCRIPTION
## Type
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
The generator code snippet was missing the `_`. I only add them after testing the code. It works now
