### PR TITLE
fix(docs): correct sequence of operations example code

### DIFF
--- a/content/docs/400-guides/250-resource-management/200-patterns/100-sequence-of-operations-with-compensating-actions-on-failure.mdx
+++ b/content/docs/400-guides/250-resource-management/200-patterns/100-sequence-of-operations-with-compensating-actions-on-failure.mdx
@@ -486,7 +486,7 @@ Now, let's simulate a failure in the `Database`:
 ```ts
 const runnable = Workspace.make.pipe(
   Effect.provide(layer),
-  Effect.provideService(Failure, "Database")
+  Effect.provideService(FailureCase, "Database")
 )
 ```
 
@@ -514,7 +514,7 @@ Let's now make the index creation fail instead:
 ```ts
 const runnable = Workspace.make.pipe(
   Effect.provide(layer),
-  Effect.provideService(Failure, "ElasticSearch")
+  Effect.provideService(FailureCase, "ElasticSearch")
 )
 ```
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The [current Sequence of Operations with Compensating Actions on Failure docs](https://effect.website/docs/guides/resource-management/patterns/sequence-of-operations-with-compensating-actions-on-failure) use `Failure` where `FailureCase` is desired (see screenshot from local implementation). This corrects that error.

![CleanShot 2024-05-22 at 12 20 31@2x](https://github.com/Effect-TS/website/assets/4946487/c5e469d1-afdb-41d2-9b76-bc858276be59)

## Related

N/A
