### PR TITLE
Allow for newly installed dependencies to be displayed in import suggestions

### DIFF
--- a/src/components/editor/services/Monaco.ts
+++ b/src/components/editor/services/Monaco.ts
@@ -111,38 +111,24 @@ const make = Effect.gen(function* () {
         })
 
       const preload = (workspace: Workspace) =>
-        Effect.all([
-          // Load the `package.json` dependencies into a `package.json` to allow
-          // the editor to provide import suggestions when doing `import X from "|"`
-          Effect.sync(() => {
-            monaco.languages.typescript.typescriptDefaults.addExtraLib(
-              JSON.stringify(
-                { dependencies: workspace.dependencies },
-                undefined,
-                2
-              ),
-              "file:///package.json"
-            )
-          }),
-          // Ensure that all workspace file paths are loaded to avoid type
-          // errors on initial load when importing from other files
-          Effect.forEach(
-            workspace.filePaths,
-            ([file, path]) =>
-              Effect.sync(() => {
-                const uri = monaco.Uri.parse(`${workspace.name}/${path}`)
-                if (monaco.editor.getModel(uri)) {
-                  return
-                }
-                monaco.editor.createModel(
-                  file.initialContent,
-                  file.language,
-                  uri
-                )
-              }),
-            { discard: true }
-          )
-        ]).pipe(Effect.asVoid)
+        // Ensure that all workspace file paths are loaded to avoid type
+        // errors on initial load when importing from other files
+        Effect.forEach(
+          workspace.filePaths,
+          ([file, path]) =>
+            Effect.sync(() => {
+              const uri = monaco.Uri.parse(`${workspace.name}/${path}`)
+              if (monaco.editor.getModel(uri)) {
+                return
+              }
+              monaco.editor.createModel(
+                file.initialContent,
+                file.language,
+                uri
+              )
+            }),
+          { discard: true }
+        )
 
       const content = Stream.async<string>((emit) => {
         const cancel = editor.onDidChangeModelContent(() => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@tim-smart - I'd like your eyes on this one. The goal is to handle modules installed via `npm i <module>` in import suggestions.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
