### PR TITLE
Make chevron in docs nav element clickable again

### DIFF
--- a/src/components/docs/navigation-link.tsx
+++ b/src/components/docs/navigation-link.tsx
@@ -68,20 +68,12 @@ export const NavigationLink: FC<{
           {element.title}
         </span>
         {element.children.length > 0 && element.collapsible && (
-          <button
-            className="h-5 w-5 flex items-center justify-center"
-            onClick={(e) => {
-              e.preventDefault()
-              setCollapsed((collapsed) => !collapsed)
-            }}
-          >
-            <Icon
-              name="chevron-right"
-              className={`h-3 -mt-0.5 transition-transform duration-200 ${
-                collapsed ? "rotate-0" : "rotate-90"
-              }`}
-            />
-          </button>
+          <Icon
+            name="chevron-right"
+            className={`h-3 -mt-0.5 transition-transform duration-200 ${
+              collapsed ? "rotate-0" : "rotate-90"
+            }`}
+          />
         )}
       </Link>
       {element.children && !collapsed && (


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the docs sidebar navigation, the chevron icons weren't clickable anymore. 
Now, when you click the icon, the section expands/collapses.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
