### PR TITLE
Replace "extendible" with "extensible"

### DIFF
--- a/content/docs/400-guides/100-essentials/600-pipeline.mdx
+++ b/content/docs/400-guides/100-essentials/600-pipeline.mdx
@@ -1,6 +1,6 @@
 ---
 title: Building Pipelines
-excerpt: Explore the power of Effect pipelines for composing and sequencing operations on values. Learn about key functions like `pipe`, `Effect.map`, `Effect.flatMap`, `Effect.andThen`, `Effect.tap`, and `Effect.all` for building modular and concise transformations. Understand the advantages of using functions over methods in the Effect ecosystem for tree shakeability and extendibility.
+excerpt: Explore the power of Effect pipelines for composing and sequencing operations on values. Learn about key functions like `pipe`, `Effect.map`, `Effect.flatMap`, `Effect.andThen`, `Effect.tap`, and `Effect.all` for building modular and concise transformations. Understand the advantages of using functions over methods in the Effect ecosystem for tree shakeability and extensibility.
 bottomNavigation: pagination
 ---
 
@@ -58,7 +58,7 @@ In the above example, we start with an input value of `5`. The `increment` funct
 
 ## Functions vs Methods
 
-In the Effect ecosystem, libraries often expose functions rather than methods. This design choice is important for two key reasons: tree shakeability and extendibility.
+In the Effect ecosystem, libraries often expose functions rather than methods. This design choice is important for two key reasons: tree shakeability and extensibility.
 
 ### Tree Shakeability
 
@@ -68,15 +68,15 @@ When functions are used in the Effect ecosystem, only the functions that are act
 
 On the other hand, methods are attached to objects or prototypes, and they cannot be easily tree shaken. Even if you only use a subset of methods, all methods associated with an object or prototype will be included in the bundle, leading to unnecessary code bloat.
 
-### Extendibility
+### Extensibility
 
-Another important advantage of using functions in the Effect ecosystem is the ease of extendibility. With methods, extending the functionality of an existing API often requires modifying the prototype of the object, which can be complex and error-prone.
+Another important advantage of using functions in the Effect ecosystem is the ease of extensibility. With methods, extending the functionality of an existing API often requires modifying the prototype of the object, which can be complex and error-prone.
 
 In contrast, with functions, extending the functionality is much simpler. You can define your own "extension methods" as plain old functions without the need to modify the prototypes of objects. This promotes cleaner and more modular code, and it also allows for better compatibility with other libraries and modules.
 
 <Idea>
   The use of functions in the Effect ecosystem libraries is important for
-  achieving **tree shakeability** and ensuring **extendibility**. Functions
+  achieving **tree shakeability** and ensuring **extensibility**. Functions
   enable efficient bundling by eliminating unused code, and they provide a
   flexible and modular approach to extending the libraries' functionality.
 </Idea>


### PR DESCRIPTION

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

see https://english.stackexchange.com/a/90444/25023 : 

- I use extendable in cases where it means the opposite of retractable. In other words, a telescoping wand is extendable, the legs of my camera tripod are extendable.

- I use extensible when I mean that the functionality of something may be increased or enhanced by the addition of an extension- an add-on module or component. My web browser is extensible because I can add an Adobe Flash extension which allows me to view flash content. I think it would sound a bit odd to talk about my web-browser being extendable.
