### PR TITLE
Fix slug generation

### DIFF
--- a/src/components/atoms/headings.tsx
+++ b/src/components/atoms/headings.tsx
@@ -1,40 +1,61 @@
 "use client"
 
-import { sluggifyTitle, getNodeText } from "@/contentlayer/utils/sluggify"
-
-export const H2: React.FC<React.PropsWithChildren<{id?: string}>> = ({ id, children }) => {
-
+export const H2: React.FC<React.PropsWithChildren<{ id?: string }>> = ({
+  id,
+  children
+}) => {
   return (
     <>
-      <a className="block invisible relative -top-28" id={id}/>
-      <h2 onClick={() => (window.location.hash = `#${id}`)} className="group cursor-pointer">
-        <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">#</span>
+      <a className="block invisible relative -top-28" id={id} />
+      <h2
+        onClick={() => (window.location.hash = `#${id}`)}
+        className="group cursor-pointer"
+      >
+        <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">
+          #
+        </span>
         {children}
       </h2>
     </>
   )
 }
 
-export const H3: React.FC<React.PropsWithChildren<{id?:string}>> = ({ id, children }) => {
-  const slug = sluggifyTitle(getNodeText(children))
+export const H3: React.FC<React.PropsWithChildren<{ id?: string }>> = ({
+  id,
+  children
+}) => {
   return (
-     <>
-      <a className="block invisible relative -top-28" id={id}/>
-    <h3 onClick={() => (window.location.hash = `#${id}`)} className="group cursor-pointer">
-      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">#</span>
-      {children}
-    </h3></>
+    <>
+      <a className="block invisible relative -top-28" id={id} />
+      <h3
+        onClick={() => (window.location.hash = `#${id}`)}
+        className="group cursor-pointer"
+      >
+        <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">
+          #
+        </span>
+        {children}
+      </h3>
+    </>
   )
 }
 
-export const H4: React.FC<React.PropsWithChildren<{id?: string}>> = ({ id, children }) => {
-  const slug = sluggifyTitle(getNodeText(children))
+export const H4: React.FC<React.PropsWithChildren<{ id?: string }>> = ({
+  id,
+  children
+}) => {
   return (
-     <>
-      <a className="block invisible relative -top-28" id={id}/>
-    <h4 onClick={() => (window.location.hash = `#${id}`)} className="group cursor-pointer">
-      <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">#</span>
-      {children}
-    </h4></>
+    <>
+      <a className="block invisible relative -top-28" id={id} />
+      <h4
+        onClick={() => (window.location.hash = `#${id}`)}
+        className="group cursor-pointer"
+      >
+        <span className="absolute -left-6 hidden font-normal text-zinc-400 lg:group-hover:inline">
+          #
+        </span>
+        {children}
+      </h4>
+    </>
   )
 }

--- a/src/components/docs/table-of-contents.tsx
+++ b/src/components/docs/table-of-contents.tsx
@@ -50,7 +50,9 @@ export const TableOfContents: React.FC<{
                   className="mt-2.5"
                   style={{ paddingLeft: `${level > 1 ? level - 2 : 0}rem` }}
                 >
-                  <Link href={`#${slug}`} className={`flex items-center pb-1 hover:text-black dark:hover:text-white leading-snug text-left ${
+                  <Link
+                    href={`#${slug}`}
+                    className={`flex items-center pb-1 hover:text-black dark:hover:text-white leading-snug text-left ${
                       slug === activeHeading
                         ? "text-black font-normal dark:text-white dark:font-light"
                         : ""
@@ -59,7 +61,8 @@ export const TableOfContents: React.FC<{
                       __html: title
                         .replace("`", "<code>")
                         .replace("`", "</code>")
-                    }}/>
+                    }}
+                  />
                 </li>
               )
             })}

--- a/src/contentlayer/utils/toc-plugin.ts
+++ b/src/contentlayer/utils/toc-plugin.ts
@@ -1,16 +1,21 @@
-import type * as unified from 'unified'
+import type * as unified from "unified"
 import GithubSlugger from "github-slugger"
 import { toString } from "hast-util-to-string"
-
-const slugger = new GithubSlugger()
 
 export const tocPlugin =
   (headings: DocHeading[]): unified.Plugin =>
   () => {
+    const slugger = new GithubSlugger()
     return (node: any) => {
-      for (const element of node.children.filter((_: any) => _.type === 'heading')) {
+      for (const element of node.children.filter(
+        (_: any) => _.type === "heading"
+      )) {
         const title = toString(element)
-        headings.push({level: element.depth, title, slug: slugger.slug(title)})
+        headings.push({
+          level: element.depth,
+          title,
+          slug: slugger.slug(title)
+        })
       }
     }
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -58,7 +58,9 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-feature-settings: "rlig" 1, "calt" 1;
+    font-feature-settings:
+      "rlig" 1,
+      "calt" 1;
   }
 }
 
@@ -91,7 +93,8 @@ body.no-scroll {
   min-height: calc(100vh - 4rem);
 }
 
-.docs-container aside, .blog-container aside {
+.docs-container aside,
+.blog-container aside {
   max-height: calc(100vh - 8rem);
 }
 

--- a/src/types/doc-heading.d.ts
+++ b/src/types/doc-heading.d.ts
@@ -1,1 +1,1 @@
-type DocHeading = {level: 1 | 2 | 3; title: string}
+type DocHeading = { level: 1 | 2 | 3; title: string; slug: string }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

The heading slug generation was handling duplicates globally instead of per-page. This was causing slugs to have postfixes like '-1' even it there was no duplicate slug on the page. Therefore, the links were broken.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #712
