### PR TITLE
Support twoslash inline hints `//^?` in playground

### DIFF
--- a/src/components/editor/rx.ts
+++ b/src/components/editor/rx.ts
@@ -12,12 +12,14 @@ import { themeRx } from "@/rx/theme"
 import { File, FullPath } from "@/workspaces/domain/workspace"
 import { RxWorkspaceHandle } from "@/workspaces/rx"
 import { MonacoATA } from "./services/Monaco/ata"
+import { MonacoTwoslashLive } from "./services/Monaco/twoslash"
 import { MonacoCompletersLive } from "./services/Monaco/completers"
 import { MonacoFormattersLive } from "./services/Monaco/formatters"
 import { MonacoTSConfigLive } from "./services/Monaco/tsconfig"
 import { FileSystemEvent } from "@/workspaces/services/WebContainer"
 
 const MonacoWithPlugins = MonacoATA.Live.pipe(
+  Layer.provide(MonacoTwoslashLive),
   Layer.provide(MonacoCompletersLive),
   Layer.provide(MonacoFormattersLive),
   Layer.provide(MonacoTSConfigLive)

--- a/src/components/editor/services/Monaco/twoslash.ts
+++ b/src/components/editor/services/Monaco/twoslash.ts
@@ -1,0 +1,98 @@
+import { Effect, Layer } from "effect"
+import type * as monaco from "monaco-editor/esm/vs/editor/editor.api"
+import type ts from "typescript"
+import { Monaco, type MonacoApi } from "../Monaco"
+
+export const make = Effect.gen(function* () {
+  const { monaco } = yield* Monaco
+
+  setupTwoslash(monaco)
+})
+
+export const MonacoTwoslashLive = Layer.effectDiscard(make).pipe(
+  Layer.provide(Monaco.Live)
+)
+
+function setupTwoslash(monaco: MonacoApi) {
+  monaco.languages.registerInlayHintsProvider(
+    [
+      { language: "javascript" },
+      { language: "typescript" },
+      { language: "typescriptreact" },
+      { language: "javascriptreact" }
+    ],
+    {
+      displayName: "twoslash",
+      provideInlayHints: async (model, _, cancellationToken) => {
+        const text = model.getValue()
+        const queryRegex = /^\s*\/\/\.?\s*\^\?/gm
+        const inlineQueryRegex =
+          /^[^\S\r\n]*(?<start>\S).*\/\/\s*(?<end>=>)/gm
+        const results: Array<monaco.languages.InlayHint> = []
+
+        const worker = await monaco.languages.typescript
+          .getTypeScriptWorker()
+          .then((worker) => worker(model.uri))
+
+        if (model.isDisposed()) {
+          return {
+            hints: [],
+            dispose: () => {}
+          }
+        }
+        let match
+
+        while ((match = queryRegex.exec(text)) !== null) {
+          const end = match.index + match[0].length - 1
+          const endPos = model.getPositionAt(end)
+          const inspectionPos = new monaco.Position(
+            endPos.lineNumber - 1,
+            endPos.column
+          )
+          const inspectionOff = model.getOffsetAt(inspectionPos)
+
+          if (cancellationToken.isCancellationRequested) {
+            return {
+              hints: [],
+              dispose: () => {}
+            }
+          }
+
+          const hint: ts.QuickInfo | undefined =
+            await worker.getQuickInfoAtPosition(
+              "file://" + model.uri.path,
+              inspectionOff
+            )
+
+          if (!hint || !hint.displayParts) {
+            continue
+          }
+
+          // Make a one-liner
+          let text = hint.displayParts
+            .map((d) => d.text)
+            .join("")
+            .replace(/\\n/g, " ")
+            .replace(/\/n/g, " ")
+            .replace(/  /g, " ")
+            .replace(/[\u0000-\u001F\u007F-\u009F]/g, "")
+
+          const inlay: monaco.languages.InlayHint = {
+            kind: monaco.languages.InlayHintKind.Type,
+            position: new monaco.Position(
+              endPos.lineNumber,
+              endPos.column + 1
+            ),
+            label: text,
+            paddingLeft: true
+          }
+          results.push(inlay)
+        }
+        return {
+          hints: results,
+          dispose: () => {}
+        }
+      }
+    }
+  )
+}


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Mostly ~~stolen~~ borrowed from here https://github.com/microsoft/TypeScript-Website/blob/v2/packages/playground/src/twoslashInlays.ts
![image](https://github.com/Effect-TS/website/assets/16162053/011c49e0-2f66-4268-b544-c784efbe0aa5)

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
