### PR TITLE
Link to specific documentation page in survey section

### DIFF
--- a/src/components/sections/features.tsx
+++ b/src/components/sections/features.tsx
@@ -32,7 +32,7 @@ export const Features = () => {
             application, your package.json will have never been this small.
           </p>
           <Checklist items={['Data validation & serialization', 'Frameworks for CLI & HTTP applications', 'Powerful abstractions for every platform']} />
-          <Button href="/docs" secondary className="mt-10">
+          <Button href="/docs/other/api-reference" secondary className="mt-10">
             Read documentation
           </Button>
         </div>
@@ -46,7 +46,7 @@ export const Features = () => {
             Successfully handle failure with the built-in error-handling primitives.
           </p>
           <Checklist items={['Type-safe errors as values', 'Powerful retry & recovery APIs', 'Tools for logging & tracing']} />
-          <Button href="/docs" secondary className="mt-10">
+          <Button href="/docs/guides/error-management" secondary className="mt-10">
             Read documentation
           </Button>
         </div>

--- a/src/components/sections/js-survey.tsx
+++ b/src/components/sections/js-survey.tsx
@@ -15,7 +15,7 @@ to make building applications easier.
     heading: "Most desired JS features",
     subheading: "2022 State of JavaScript survey",
     features: [
-      { name: "2. Standard Library", value: 12928, docsLink: "/docs/other/api-reference" },
+      { name: "2. Standard Library", value: 12928, docsLink: "/docs" },
       {
         name: "4. Immutable Data Structures",
         value: 8243,

--- a/src/components/sections/js-survey.tsx
+++ b/src/components/sections/js-survey.tsx
@@ -15,15 +15,15 @@ to make building applications easier.
     heading: "Most desired JS features",
     subheading: "2022 State of JavaScript survey",
     features: [
-      { name: "2. Standard Library", value: 12928, docsLink: "/docs" },
+      { name: "2. Standard Library", value: 12928, docsLink: "/docs/other/api-reference" },
       {
         name: "4. Immutable Data Structures",
         value: 8243,
-        docsLink: "/docs"
+        docsLink: "/docs/other/data-types"
       },
-      { name: "5. Observable", value: 6515, docsLink: "/docs" },
-      { name: "6. Pipe Operator", value: 5860, docsLink: "/docs" },
-      { name: "8. Pattern Matching", value: 4872, docsLink: "/docs" }
+      { name: "5. Observable", value: 6515, docsLink: "/docs/guides/streaming/stream/introduction" },
+      { name: "6. Pipe Operator", value: 5860, docsLink: "/docs/guides/essentials/pipeline" },
+      { name: "8. Pattern Matching", value: 4872, docsLink: "/docs/guides/style/pattern-matching" }
     ]
   }
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Links inside the survey section on the index page currently all points to the documentation index (`/docs`), which is confusing and less useful.

It would be better if the links points to the corresponding documentation pages.

I try to assign the most related page to each feature, but suggestions are very welcome.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
