### PR TITLE
Update Pipeline Documentation

### DIFF
--- a/content/docs/400-guides/100-essentials/600-pipeline.mdx
+++ b/content/docs/400-guides/100-essentials/600-pipeline.mdx
@@ -309,12 +309,12 @@ However, it is important to understand that when these types are used, the opera
 import { pipe, Effect, Option } from "effect"
 
 // Simulated asynchronous task fetching a number from a database
-const fetchStringValue = Effect.promise(() => Promise.resolve(42))
+const fetchNumberValue = Effect.promise(() => Promise.resolve(42))
 
 // Although one might expect the type to be Effect<Option<number>, never, never>,
 // it is actually Effect<number, NoSuchElementException, never>
 const program = pipe(
-  fetchStringValue,
+  fetchNumberValue,
   Effect.andThen((x) => (x > 0 ? Option.some(x) : Option.none()))
 )
 ```


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Updating variable name as from:
```
import { pipe, Effect, Option } from "effect"
 
// Simulated asynchronous task fetching a number from a database
const fetchStringValue = Effect.promise(() => Promise.resolve(42))
 
// Although one might expect the type to be Effect<Option<number>, never, never>,
// it is actually Effect<number, NoSuchElementException, never>
const program = pipe(
  fetchStringValue,
  Effect.andThen((x) => (x > 0 ? Option.some(x) : Option.none()))
)
```
to
```
import { pipe, Effect, Option } from "effect"
 
// Simulated asynchronous task fetching a number from a database
const fetchNumberValue = Effect.promise(() => Promise.resolve(42))
 
// Although one might expect the type to be Effect<Option<number>, never, never>,
// it is actually Effect<number, NoSuchElementException, never>
const program = pipe(
  fetchNumberValue,
  Effect.andThen((x) => (x > 0 ? Option.some(x) : Option.none()))
)
```
As the promise resolves to a `number` and not a `string`
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
