### PR TITLE
docs(schema): fix typo in basic usage

### DIFF
--- a/content/docs/400-guides/800-schema/200-basic-usage.mdx
+++ b/content/docs/400-guides/800-schema/200-basic-usage.mdx
@@ -518,7 +518,7 @@ Schema.String.pipe(Schema.lowercased())
 <Info>
   The `trimmed` combinator does not make any transformations, it only
   validates. If what you were looking for was a combinator to trim strings,
-  then check out the `trim` combinator ot the `Trim` schema.
+  then check out the `trim` combinator or the `Trim` schema.
 </Info>
 
 ### Number Filters


### PR DESCRIPTION
Fixed small typo in schema basic usage.
