### PR TITLE
Fix typos and deduplicate comments

### DIFF
--- a/content/docs/400-guides/150-error-management/700-timing-out.mdx
+++ b/content/docs/400-guides/150-error-management/700-timing-out.mdx
@@ -22,7 +22,7 @@ import { Effect } from "effect"
 
 const myEffect = Effect.gen(function* () {
   console.log("Start processing...")
-  yield* Effect.sleep("2 seconds") // Simulates a delay in processing // Simulates a delay in processing
+  yield* Effect.sleep("2 seconds") // Simulates a delay in processing
   console.log("Processing complete.")
   return "Result"
 })

--- a/content/docs/400-guides/640-concurrency/160-semaphore.mdx
+++ b/content/docs/400-guides/640-concurrency/160-semaphore.mdx
@@ -60,7 +60,7 @@ const program = Effect.gen(function* () {
         .withPermits(n)(
           Effect.delay(Effect.log(`process: ${n}`), "2 seconds")
         )
-        .pipe(Effect.withLogSpan("elasped")),
+        .pipe(Effect.withLogSpan("elapsed")),
     { concurrency: "unbounded" }
   )
 })
@@ -68,11 +68,11 @@ const program = Effect.gen(function* () {
 Effect.runPromise(program)
 /*
 Output:
-timestamp=... level=INFO fiber=#1 message="process: 1" elasped=2011ms
-timestamp=... level=INFO fiber=#2 message="process: 2" elasped=2017ms
-timestamp=... level=INFO fiber=#3 message="process: 3" elasped=4020ms
-timestamp=... level=INFO fiber=#4 message="process: 4" elasped=6025ms
-timestamp=... level=INFO fiber=#5 message="process: 5" elasped=8034ms
+timestamp=... level=INFO fiber=#1 message="process: 1" elapsed=2011ms
+timestamp=... level=INFO fiber=#2 message="process: 2" elapsed=2017ms
+timestamp=... level=INFO fiber=#3 message="process: 3" elapsed=4020ms
+timestamp=... level=INFO fiber=#4 message="process: 4" elapsed=6025ms
+timestamp=... level=INFO fiber=#5 message="process: 5" elapsed=8034ms
 */
 ```
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request fixes small typos, changing "elasped" to "elapsed", and removes a duplicated comment.

## Related

This PR does not relate to or close any issues.