### PR TITLE
remove footer from playground layout

### DIFF
--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,11 @@
+import { Footer } from "@/components/layout/footer"
+import { ReactNode } from "react"
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}
+      <Footer />
+    </>
+  )
+}

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,4 +1,5 @@
 import { Navigation as DocsNavigation } from "@/components/docs/navigation"
+import { Footer } from "@/components/layout/footer"
 import { Navigation } from "@/components/layout/navigation"
 import { ReactNode } from "react"
 
@@ -10,6 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <DocsNavigation className="hidden md:flex" />
         {children}
       </div>
+      <Footer />
     </>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="relative overflow-x-hidden antialiased font-light bg-white dark:bg-[#09090B] text-zinc-700 dark:text-zinc-300">
         <Providers>
           {children}
-          <Footer />
           <Analytics />
         </Providers>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Footer } from "@/components/layout/footer"
 import { Navigation } from "@/components/layout/navigation"
 import { Catch } from "@/components/sections/catch"
 import { Community } from "@/components/sections/community"
@@ -30,6 +31,7 @@ export default function HomePage() {
         <Community />
         <CTA />
       </main>
+      <Footer />
     </>
   )
 }

--- a/src/app/tutorials/layout.tsx
+++ b/src/app/tutorials/layout.tsx
@@ -1,3 +1,4 @@
+import { Footer } from "@/components/layout/footer"
 import { Navigation } from "@/components/layout/navigation"
 import { Toaster } from "@/components/ui/toaster"
 import { ReactNode } from "react"
@@ -10,6 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         {children}
       </div>
       <Toaster />
+      <Footer />
     </>
   )
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

when scrolling outside the code editing area, the page scrolls down to show the footer - this is inconvenient. I removed the footer from the root layout and moved it to all child pages except the playground page
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
