### PR TITLE
Display value in schema constraint error

### DIFF
--- a/content/docs/400-guides/800-schema/350-annotations.mdx
+++ b/content/docs/400-guides/800-schema/350-annotations.mdx
@@ -23,7 +23,7 @@ const Password =
       Schema.nonEmptyString({ message: () => "required" }),
       // add a constraint to the schema, only strings with a length less or equal than 10 are valid
       // and add an error message for strings that are too long
-      Schema.maxLength(10, { message: (s) => `${s} is too long` })
+      Schema.maxLength(10, { message: (s) => `${s.actual} is too long` })
       // add an identifier to the schema
     )
     .annotations({

--- a/content/docs/400-guides/800-schema/350-annotations.mdx
+++ b/content/docs/400-guides/800-schema/350-annotations.mdx
@@ -24,7 +24,6 @@ const Password =
       // add a constraint to the schema, only strings with a length less or equal than 10 are valid
       // and add an error message for strings that are too long
       Schema.maxLength(10, { message: (s) => `${s.actual} is too long` })
-      // add an identifier to the schema
     )
     .annotations({
       // add an identifier to the schema


### PR DESCRIPTION


## Type

📓 Documentation Update

## Description

Previous version of the example would print `[object Object]` (the `ParseIssue`) to console, which is not a good experience. 
Now, the example displays the inputted value in error.

[Playground](https://effect.website/play#e1e84ba66ad6)
