### PR TITLE
Ensure that Pagefind ignores Twoslash popup content

### DIFF
--- a/content/astro.config.ts
+++ b/content/astro.config.ts
@@ -15,6 +15,7 @@ import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-s
 import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers"
 import ecTwoSlash from "expressive-code-twoslash"
 import { pluginOpenInPlayground } from "./src/plugins/expressive-code/open-in-playground"
+import { pluginTwoslashPagefind } from "./src/plugins/expressive-code/twoslash-pagefind"
 import { effectPlaygroundPlugin } from "./src/plugins/starlight/playground"
 import { monacoEditorPlugin } from "./src/plugins/vite/monaco-editor"
 
@@ -141,7 +142,8 @@ export default defineConfig({
           pluginCollapsibleSections(),
           pluginLineNumbers(),
           pluginOpenInPlayground(),
-          ecTwoSlash()
+          ecTwoSlash(),
+          pluginTwoslashPagefind()
         ],
         themes: ["github-light", "github-dark"]
       },

--- a/content/src/plugins/expressive-code/twoslash-pagefind.ts
+++ b/content/src/plugins/expressive-code/twoslash-pagefind.ts
@@ -1,0 +1,20 @@
+import type { ExpressiveCodePlugin } from "@expressive-code/core"
+import { h, selectAll } from "@expressive-code/core/hast"
+
+export function pluginTwoslashPagefind(): ExpressiveCodePlugin {
+  return {
+    name: "TwoslashPagefind",
+    hooks: {
+      postprocessRenderedBlock({ codeBlock, renderData }) {
+        const isTS = codeBlock.language === "ts"
+        const hasTwoslash = /\btwoslash\b/.test(codeBlock.meta)
+        if (isTS && hasTwoslash) {
+          const elements = selectAll("div.twoslash-popup-container", renderData.blockAst)
+          for (const element of elements) {
+            element.properties["data-pagefind-ignore"] = true
+          }
+        }
+      }
+    }
+  }
+}

--- a/content/src/plugins/expressive-code/twoslash-pagefind.ts
+++ b/content/src/plugins/expressive-code/twoslash-pagefind.ts
@@ -1,5 +1,5 @@
 import type { ExpressiveCodePlugin } from "@expressive-code/core"
-import { h, selectAll } from "@expressive-code/core/hast"
+import { selectAll } from "@expressive-code/core/hast"
 
 export function pluginTwoslashPagefind(): ExpressiveCodePlugin {
   return {

--- a/content/src/styles/twoslash.css
+++ b/content/src/styles/twoslash.css
@@ -1,3 +1,11 @@
 .expressive-code .twoslash-popup-container {
   --ec-twoSlash-brdCol: var(--ec-gtrFg);
 }
+
+.expressive-code .twoslash-popup-container .twoslash-popup-docs .expressive-code pre {
+  border: var(--ec-brdWd) solid var(--ec-brdCol) !important;
+}
+
+.expressive-code .twoslash-popup-container .twoslash-popup-docs .ec-line {
+  line-height: var(--ec-codeLineHt);
+}


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a small Expressive Code plugin that injects a `data-pagefind-ignore` attribute into the attributes of the root element of a Twoslash popup container. This ensures that this content will not be included in search results.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #935 
- Closes #935
