### PR TITLE
Fix the `pnpm init` command for manual installation

### DIFF
--- a/content/src/content/docs/docs/getting-started/installation.mdx
+++ b/content/src/content/docs/docs/getting-started/installation.mdx
@@ -95,7 +95,7 @@ Follow these steps to create a new Effect project for [Node.js](https://nodejs.o
    <TabItem label="pnpm" icon="pnpm">
 
    ```sh showLineNumbers=false
-   pnpm init -y
+   pnpm init
    pnpm add --save-dev typescript
    ```
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

`pnpm init` doesn't support the `-y` flag. Instead it is the default. Below is an example output if you run the command in the previous version:

> ERROR  Unknown option: 'y'

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
