### PR TITLE
Fix/broken effect type link and typos

### DIFF
--- a/content/src/content/docs/docs/schema/advanced-usage.mdx
+++ b/content/src/content/docs/docs/schema/advanced-usage.mdx
@@ -389,7 +389,7 @@ age: PropertySignature<
 | `ToToken`    | Indicates field requirement: `"?:"` for optional, `":"` for required                                                |
 | `ToType`     | Type of the "To" field                                                                                              |
 | `FromKey`    | (Optional, default = `never`) Indicates the source field key, typically the same as "To" field key unless specified |
-| `FormToken`  | Indicates source field requirement: `"?:"` for optional, `":"` for required                                         |
+| `FromToken`  | Indicates source field requirement: `"?:"` for optional, `":"` for required                                         |
 | `FromType`   | Type of the "From" field                                                                                            |
 | `HasDefault` | Indicates if there is a constructor default value (Boolean)                                                         |
 
@@ -407,7 +407,7 @@ This means:
 | `ToToken`    | `":"` indicates that the `age` field is required                           |
 | `ToType`     | Type of the `age` field is `number`                                        |
 | `FromKey`    | `never` indicates that the decoding occurs from the same field named `age` |
-| `FormToken`  | `":"` indicates that the decoding occurs from a required `age` field       |
+| `FromToken`  | `":"` indicates that the decoding occurs from a required `age` field       |
 | `FromType`   | Type of the "From" field is `string`                                       |
 | `HasDefault` | `false`: indicates there is no default value                               |
 
@@ -1747,13 +1747,13 @@ Structs provide access to their fields through the `fields` property, which allo
 ```ts twoslash
 import { Schema } from "effect"
 
-const Orginal = Schema.Struct({
+const Original = Schema.Struct({
   a: Schema.String,
   b: Schema.String
 })
 
 const Extended = Schema.Struct({
-  ...Orginal.fields,
+  ...Original.fields,
   // Adding new fields
   c: Schema.String,
   d: Schema.String

--- a/content/src/content/docs/docs/schema/introduction.mdx
+++ b/content/src/content/docs/docs/schema/introduction.mdx
@@ -121,7 +121,7 @@ The `Schema` type has three type parameters with the following meanings:
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Type**         | Represents the type of value that a schema can succeed with during decoding.                                                                                                                                                                                                                                       |
 | **Encoded**      | Represents the type of value that a schema can succeed with during encoding. By default, it's equal to `Type` if not explicitly provided.                                                                                                                                                                          |
-| **Requirements** | Similar to the [`Effect`](https://effect.website/docs/docs/getting-started/the-effect-type) type, it represents the contextual data required by the schema to execute both decoding and encoding. If this type parameter is `never` (default if not explicitly provided), it means the schema has no requirements. |
+| **Requirements** | Similar to the [`Effect`](https://effect.website/docs/getting-started/the-effect-type) type, it represents the contextual data required by the schema to execute both decoding and encoding. If this type parameter is `never` (default if not explicitly provided), it means the schema has no requirements. |
 
 **Examples**
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

Hello, 
As always, thanks for the amazing project. I noticed a couple of issues in the documentation.

I fixed a broken link to the Effect Type page in the Introduction to Effect Schema and addressed typos in the "advanced usage" section of the documentation. Not super critical issues, but makes everything more readable. :)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
