### PR TITLE
fix typo ("as as") in creating-effects.mdx

### DIFF
--- a/content/src/content/docs/docs/getting-started/creating-effects.mdx
+++ b/content/src/content/docs/docs/getting-started/creating-effects.mdx
@@ -332,7 +332,7 @@ Creates an `Effect` that represents an asynchronous computation that might fail.
 
 Unlike `Effect.promise`, this constructor is suitable when the underlying `Promise` might reject.
 It provides a way to catch errors and handle them appropriately.
-By default if an error occurs, it will be caught and propagated to the error channel as as an `UnknownException`.
+By default if an error occurs, it will be caught and propagated to the error channel as an `UnknownException`.
 
 **Example** (Fetching a TODO Item)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Removes extra "as" in the documentation, just a small typo fix.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
