### PR TITLE
Fix typo in combine schema transform example

### DIFF
--- a/content/src/content/docs/docs/schema/transformations.mdx
+++ b/content/src/content/docs/docs/schema/transformations.mdx
@@ -145,7 +145,7 @@ const BooleanFromNumericString = Schema.transform(
     // If number is positive, use "on", otherwise "off"
     decode: (n) => (n > 0 ? "on" : "off"),
     // If boolean is true, use 1, otherwise -1
-    encode: (bool) => (bool ? 1 : -1)
+    encode: (bool) => (bool === "on" ? 1 : -1)
   }
 )
 

--- a/content/src/content/docs/docs/schema/transformations.mdx
+++ b/content/src/content/docs/docs/schema/transformations.mdx
@@ -144,7 +144,7 @@ const BooleanFromNumericString = Schema.transform(
     strict: true,
     // If number is positive, use "on", otherwise "off"
     decode: (n) => (n > 0 ? "on" : "off"),
-    // If boolean is true, use 1, otherwise -1
+    // If boolean is "on", use 1, otherwise -1
     encode: (bool) => (bool === "on" ? 1 : -1)
   }
 )


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The example in the docs contained a small typo when encoding boolean string as a number

## Related

None

- Related Issue #
- Closes #
