### PR TITLE
Update NumberFromString documentation about used parser

### DIFF
--- a/content/src/content/docs/docs/schema/transformations.mdx
+++ b/content/src/content/docs/docs/schema/transformations.mdx
@@ -992,7 +992,11 @@ console.log(Schema.encodeSync(UrlSchema)({ maxItemPerPage: 10, page: 1 }))
 
 ### NumberFromString
 
-Converts a string to a number using `parseFloat`, supporting special values "NaN", "Infinity", and "-Infinity".
+Transforms a string into a number by parsing the string using the `parse` function of the `effect/Number` module.
+
+It returns an error if the value can't be converted (for example when non-numeric characters are provided).
+
+The following special string values are supported: "NaN", "Infinity", "-Infinity".
 
 **Example** (Parsing Number from String)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Documentations for `Schema.NumberFromString` currently mentions using `parseFloat` while `Schema.parseNumber` mentions using `effect/Number` module for parsing. 

`Schema.NumberFromString` now actually just uses `Schema.parseNumber` which means it also uses `effect/Number` for parsing.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
