### PR TITLE
Fix documentation to reference Exit.failCause instead of Exit.fail

### DIFF
--- a/content/src/content/docs/docs/data-types/exit.mdx
+++ b/content/src/content/docs/docs/data-types/exit.mdx
@@ -42,7 +42,7 @@ console.log(successExit)
 import { Exit, Cause } from "effect"
 
 // Create an Exit representing a failure with an error message
-const failureExit = Exit.fail(Cause.fail("Something went wrong"))
+const failureExit = Exit.failCause(Cause.fail("Something went wrong"))
 
 console.log(failureExit)
 /*


### PR DESCRIPTION
I'm trying to be helpful, but ignore this if I've done it wrong. Simply changing Exit.fail to Exit.failCause, to correct the documentation. I could not run the tests, because I'm uncertain if there's any for the /website.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue [1120](https://github.com/Effect-TS/website/issues/1120)
- Closes [1120](https://github.com/Effect-TS/website/issues/1120)
