### PR TITLE
Fix managed runtime example type hovering

### DIFF
--- a/content/src/content/docs/docs/runtime.mdx
+++ b/content/src/content/docs/docs/runtime.mdx
@@ -268,7 +268,7 @@ class Notifications extends Effect.Tag("Notifications")<
 
 // Create an effect that depends on the Notifications service
 //
-//      ┌─── Effect.Effect<void, never, Notifications>
+//      ┌─── Effect<void, never, Notifications>
 //      ▼
 const action = Notifications.notify("Hello, world!")
 ```

--- a/content/src/content/docs/docs/runtime.mdx
+++ b/content/src/content/docs/docs/runtime.mdx
@@ -267,8 +267,10 @@ class Notifications extends Effect.Tag("Notifications")<
 >() {}
 
 // Create an effect that depends on the Notifications service
+//
+//      ┌─── Effect.Effect<void, never, Notifications>
+//      ▼
 const action = Notifications.notify("Hello, world!")
-//    ^? const action: Effect<void, never, Notifications>
 ```
 
 In this example, the `action` effect depends on the `Notifications` service. This approach allows you to reference services without manually passing them around. Later, you can create a `Layer` that provides the `Notifications` service and build a `ManagedRuntime` with that layer to ensure the service is available where needed.


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

I think there is an artifact within the example of [managed runtime Effect.Tag](https://effect.website/docs/runtime/#effecttag) where the type of the `action` variable is always shown as if we were hovering over it

I just move the type in a proper comment above the variable based on other examples within the docs

before change

![Screenshot from 2025-04-25 04-13-12](https://github.com/user-attachments/assets/fe269680-aebf-4e79-92c2-ab4d007eb30f)
after change

![Screenshot from 2025-04-25 04-12-57](https://github.com/user-attachments/assets/0a9eec42-e22e-435f-89b3-b45586909084)


## Related