### PR TITLE
Incorrect documentation on `undefined` in `Schema.filter`

### DIFF
--- a/content/src/content/docs/docs/schema/filters.mdx
+++ b/content/src/content/docs/docs/schema/filters.mdx
@@ -89,8 +89,8 @@ The filter's predicate can return several types of values, each affecting valida
 
 | Return Type                   | Behavior                                                                                         |
 | ----------------------------- | ------------------------------------------------------------------------------------------------ |
-| `true`                        | The data satisfies the filter's condition and passes validation.                                 |
-| `false` or `undefined`        | The data does not meet the condition, and no specific error message is provided.                 |
+| `true` or `undefined`         | The data satisfies the filter's condition and passes validation.                                 |
+| `false`                       | The data does not meet the condition, and no specific error message is provided.                 |
 | `string`                      | The validation fails, and the provided string is used as the error message.                      |
 | `ParseResult.ParseIssue`      | The validation fails with a detailed error structure, specifying where and why it failed.        |
 | `FilterIssue`                 | Allows for more detailed error messages with specific paths, providing enhanced error reporting. |


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

From what I can see in implementation and at runtime - returning `undefined` in filters results in success, not failure. 

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
