### PR TITLE
use Data.TaggedError as error handling example

### DIFF
--- a/landing/src/components/sections/basic-examples.tsx
+++ b/landing/src/components/sections/basic-examples.tsx
@@ -187,12 +187,11 @@ main()\
     withEffect: {
       fileName: "index.ts",
       code: `\
-import { Console, Effect } from 'effect'
+import { Console, Data, Effect } from 'effect'
 
-class CustomError {
-  readonly _tag = 'CustomError'
-  constructor(readonly value: number) {}
-}
+class CustomError extends Data.TaggedError("CustomError")<{
+  value: number
+}> {}
 
 const maybeFail: Effect.Effect<
   number,
@@ -200,11 +199,10 @@ const maybeFail: Effect.Effect<
 > = Effect.sync(() => Math.random()).pipe(
   Effect.andThen((value) =>
     value > 0.5
-      ? Effect.fail(new CustomError(value))
+      ? Effect.fail(new CustomError({ value }))
       : Effect.succeed(value),
   ),
 )
-
 
 const main = maybeFail.pipe(
   Effect.andThen((value) =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

The basic example for Effect error handling has been updated to use `Data.TaggedError` instead of a manual class definition with a tag property.

Effect should be showing the preferred way to write code when providing examples.

Before,
![before](https://github.com/user-attachments/assets/5438ef95-fabe-4b6a-912d-6a75297c3f33)

After,
![after](https://github.com/user-attachments/assets/20184c34-256f-4e39-9184-54d6c3a37a4f)

