### PR TITLE
Update Michael Arnaldi's title from CEO to BDFL

### DIFF
--- a/content/astro.config.ts
+++ b/content/astro.config.ts
@@ -196,7 +196,7 @@ export default defineConfig({
             },
             michael_arnaldi: {
               name: "Michael Arnaldi",
-              title: "Chief Executive Officer",
+              title: "BDFL",
               picture: "/authors/michael_arnaldi.png",
               url: "https://github.com/mikearnaldi"
             },


### PR DESCRIPTION
## Summary
- Update Michael Arnaldi's title from "Chief Executive Officer" to "BDFL" in author configuration
- Changes made in `content/astro.config.ts` author profile section

## Test plan
- [ ] Verify author title displays correctly on blog posts
- [ ] Check that existing blog posts with michael_arnaldi author show updated title
- [ ] Confirm no breaking changes to site build

🤖 Generated with [Claude Code](https://claude.ai/code)