### PR TITLE
add info segment about json schema validation of default values

### DIFF
--- a/content/src/content/docs/docs/schema/json-schema.mdx
+++ b/content/src/content/docs/docs/schema/json-schema.mdx
@@ -6,6 +6,8 @@ sidebar:
   order: 16
 ---
 
+import { Aside } from "@astrojs/starlight/components"
+
 The `JSONSchema.make` function allows you to generate a JSON Schema from a schema.
 
 **Example** (Creating a JSON Schema for a Struct)
@@ -628,17 +630,24 @@ By using identifier annotations, schemas can be reused and referenced more easil
 Standard JSON Schema annotations such as `title`, `description`, `default`, and `examples` are supported.
 These annotations allow you to enrich your schemas with metadata that can enhance readability and provide additional information about the data structure.
 
+<Aside type="note" title="Default values must be valid">
+  Default values are filtered by removing values that do not conform to
+  the schema.
+</Aside>
+
 **Example** (Using Annotations for Metadata)
 
 ```ts twoslash
 import { JSONSchema, Schema } from "effect"
 
-const schema = Schema.String.annotations({
-  description: "my custom description",
-  title: "my custom title",
-  default: "",
-  examples: ["a", "b"]
-})
+const schema = Schema.Trim.pipe(
+  Schema.annotations({
+    description: "my custom description",
+    title: "my custom title",
+    default: "",
+    examples: ["a", "  b", "c"]
+  })
+)
 
 const jsonSchema = JSONSchema.make(schema)
 
@@ -646,15 +655,12 @@ console.log(JSON.stringify(jsonSchema, null, 2))
 /*
 Output:
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "string",
-  "description": "my custom description",
-  "title": "my custom title",
-  "examples": [
-    "a",
-    "b"
-  ],
-  "default": ""
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  type: 'string',
+  description: 'my custom description',
+  title: 'my custom title',
+  default: '',
+  examples: [ 'a', 'c' ]
 }
 */
 ```


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This really caught me off guard when using `@effect/ai` when adding a filter to my schema reduced the quality of my results by quite a bit because I unknowingly removed all `examples` values being sent to the LLM, especially since while this behaviour makes sense it differs from inspecting `examples` on the AST 

```ts

import { JSONSchema, Schema } from "effect"

const schema = Schema.Trim.pipe(Schema.annotations({
  description: "my custom description",
  title: "my custom title",
  default: "",
  examples: ["a", "  b", "c"]
}))

console.log(schema.ast.annotations)
/*
...
{
  [Symbol(effect/annotation/Title)]: 'my custom title',
  [Symbol(effect/annotation/Description)]: 'my custom description',
  [Symbol(effect/annotation/Examples)]: [ 'a', '  b', 'c' ],
  [Symbol(effect/annotation/Default)]: ''
}
...
 */

const jsonSchema = JSONSchema.make(schema)
console.log(jsonSchema)
/*
...
{
  '$schema': 'http://json-schema.org/draft-07/schema#',
  type: 'string',
  description: 'my custom description',
  title: 'my custom title',
  default: '',
  examples: [ 'a', 'c' ]
}
...
*/
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
