### PR TITLE
fix: landing page theme switcher

### DIFF
--- a/landing/src/components/layout/navigation.tsx
+++ b/landing/src/components/layout/navigation.tsx
@@ -57,7 +57,6 @@ export const Navigation: React.FC<{
           <div className="hidden md:flex items-center gap-8">
             <NavigationMenu />
             {themeSwitcher && <ThemeSwitcher />}
-            {pathname === "/" ? null : <ThemeSwitcher />}
             <div className="flex items-center gap-4">
               {socials.map(({ name, icon, href }, index) => (
                 <Link key={index} href={href} className="generic-hover">


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes an issue that ThemeSwitcher is visible for a small amount of time on page load. Probably there's some issue with path name. ThemeSwitcher is not used at all so probably would be better to remove it overall from landing page codebase (for example line above `{themeSwitcher && <ThemeSwitcher />}` - Navigation never receives `themeSwitcher prop` from anywhere) but I didn't want to make such destructive action 😅.

## Related
- Closes #1247
