### PR TITLE
docs: Move callback after binded variable in code example

### DIFF
--- a/content/src/content/docs/docs/getting-started/creating-effects.mdx
+++ b/content/src/content/docs/docs/getting-started/creating-effects.mdx
@@ -498,17 +498,17 @@ import { Effect, Fiber } from "effect"
 
 // A task that supports interruption using AbortSignal
 const interruptibleTask = Effect.async<void, Error>((resume, signal) => {
-  // Handle interruption
-  signal.addEventListener("abort", () => {
-    console.log("Abort signal received")
-    clearTimeout(timeoutId)
-  })
-
   // Simulate a long-running task
   const timeoutId = setTimeout(() => {
     console.log("Operation completed")
     resume(Effect.void)
   }, 2000)
+
+  // Handle interruption
+  signal.addEventListener("abort", () => {
+    console.log("Abort signal received")
+    clearTimeout(timeoutId)
+  })
 })
 
 const program = Effect.gen(function* () {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Fix potential TDZ issue in Effect.async interruption example by reordering `timeoutId` initialization before registering the abort callback.
This avoids a possible ReferenceError if the abort signal is already aborted or delivered synchronously, while preserving the original behavior and intent of the example. It also makes the example less confusing.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
