### PR TITLE
Fix output comment in mocked Cache service example

### DIFF
--- a/content/src/content/docs/docs/requirements-management/layers.mdx
+++ b/content/src/content/docs/docs/requirements-management/layers.mdx
@@ -1092,7 +1092,7 @@ const cache = new Cache({
 const runnable = program.pipe(Effect.provideService(Cache, cache))
 
 Effect.runFork(runnable)
-// Output: File Content...
+// Output: Cache Content...
 ```
 
 ### Alternative Ways to Define a Service


### PR DESCRIPTION
In the "Mocking the Service Directly" section of the Requirements Management / Layers docs, the example replaces the real `Cache` service with a mock via `Effect.provideService(Cache, cache)`. The mock's `lookup` returns `Effect.succeed("Cache Content...")`, but the trailing comment still reads `// Output: File Content...`, which appears to be a leftover from the previous snippet (the FileSystem-backed test that does print `File Content...`).

Updated the comment to match what the program actually prints.

```diff
 Effect.runFork(runnable)
-// Output: File Content...
+// Output: Cache Content...
```

File: `content/src/content/docs/docs/requirements-management/layers.mdx`