### PR TITLE
Update docs to use js/ts.preferences.autoImportFileExcludePatterns

### DIFF
--- a/content/src/content/docs/blog/the-one-weird-git-trick-that-makes-coding-agents-more-effect-ive.mdx
+++ b/content/src/content/docs/blog/the-one-weird-git-trick-that-makes-coding-agents-more-effect-ive.mdx
@@ -85,10 +85,7 @@ In VSCode, you can exclude your `repos/` directory from search, file watching, a
 
 ```json
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
-    "repos/**"
-  ],
-  "javascript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "repos/**"
   ],
 


### PR DESCRIPTION
## Type
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Updated the documentation by replacing the deprecated settings `javascript.preferences.autoImportFileExcludePatterns` and `typescript.preferences.autoImportFileExcludePatterns` with `js/ts.preferences.autoImportFileExcludePatterns`.

This ensures the documentation now recommends the current, non-deprecated setting.

## Related