### PR TITLE
[docs][pipe]Add the limit the pipe can support

### DIFF
--- a/content/src/content/docs/docs/getting-started/building-pipelines.mdx
+++ b/content/src/content/docs/docs/getting-started/building-pipelines.mdx
@@ -90,6 +90,8 @@ In the above example, we start with an input value of `5`. The `increment` funct
 
 The result is equivalent to `subtractTen(double(increment(5)))`, but using `pipe` makes the code more readable because the operations are sequenced from left to right, rather than nesting them inside out.
 
+Please note that pipe currently support up to 20 functions
+
 ## map
 
 Transforms the value inside an effect by applying a function to it.


### PR DESCRIPTION
## Type

- ✅ Documentation Update

## Description

While going through the docs for pipe and using it for a specific use-case I was hit with an compilation error that I passed the max number of passed arguments, though it would be good to declare this explicitly

