### PR TITLE
fix: make docs sidebar link hover readable in dark mode

### DIFF
--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -123,7 +123,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3)
                           "flex items-center justify-between rounded px-2 py-2.5 -mx-2 font-mono text-sm font-medium tracking-wider uppercase transition-colors",
                           item.entry.id === currentId
                             ? "bg-zinc-200 text-zinc-900 dark:bg-zinc-800 dark:text-white"
-                            : "text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white",
+                            : "text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-white",
                         ]}
                       >
                         {entryLabel(item.entry)}


### PR DESCRIPTION
## Problem

In dark mode (the docs' default theme), hovering a **top-level** sidebar link — e.g. `CONFIGURATION` or `RUNTIME` — renders **white text on a near-white background**, making the label unreadable.

**Cause:** in `src/pages/docs/[...slug].astro`, the top-level entry hover state applies `hover:bg-zinc-100` (near-white) with **no** `dark:hover:bg-*` override, while `dark:hover:text-white` forces the text white. In dark mode this leaves white text on a near-white hover background.

The nested sub-nav child links in the same file already handle this correctly (they include a `dark:hover:bg-*` override).

## Fix

Add `dark:hover:bg-zinc-800` to the top-level entry hover state so the hover background matches the element's own active/selected state (`dark:bg-zinc-800`). One-line change; light mode is unchanged.

```diff
- "text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white"
+ "text-zinc-700 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-white"
```

## Screenshots

Dark mode, hovering the `CONFIGURATION` link.

**Before** — white text on a near-white background (unreadable):

<img width="360" alt="before" src="https://github.com/user-attachments/assets/bfc4314a-c879-400a-b706-0443fa6d1051" />

**After** — readable white text on `zinc-800`:

<img width="360" alt="after" src="https://github.com/user-attachments/assets/4e142a83-a21f-453a-9057-4109c44416da" />
