### PR TITLE
Small docs theme fixes

### DIFF
--- a/src/content/blog/this-week-in-effect/128/index.mdx
+++ b/src/content/blog/this-week-in-effect/128/index.mdx
@@ -25,7 +25,6 @@ To get started, below you'll find links to our documentation and our guide for i
 - [Effect Documentation](/docs/getting-started/introduction/)
 - [Installing Effect](/docs/getting-started/installation/)
 
-
 **Recent major updates:**
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
@@ -40,7 +39,7 @@ To get started, below you'll find links to our documentation and our guide for i
 ### Effect v4 Beta updates
 
 The first full week on the canonical `Effect-TS/effect` repository was packed, with a thorough `Cron` hardening pass, fiber runtime fixes, new core APIs, and continued AI and HTTP improvements — here are the most notable changes that landed this week.
- 
+
 - **Cron hardening**: Validated `Cron.make` field restrictions, fixed `Cron.prev` month day rollover and weekday wrapping, fixed alias normalization, added day and weekday intersection semantics in the inspection representation, and corrected JSDoc examples and documentation accuracy.
 
 - **Fiber runtime fixes**: Fixed fiber self-interruption from inside a running observer, cleaned up more references on fiber exit, and fixed `Fiber.joinAll` observers leaking on interruption. Also fixed cache lookup to only interrupt when all awaiters are gone.
@@ -72,8 +71,8 @@ To catch up on more updates, check out [**Effect v4 Beta updates**](https://effe
 Other technical changes from the past week.
 
 ### Effect Core
-- [Suppress unhandled logs from timeout fibers](https://github.com/Effect-TS/effect/pull/6507) (Bug Fix)
 
+- [Suppress unhandled logs from timeout fibers](https://github.com/Effect-TS/effect/pull/6507) (Bug Fix)
 
 &nbsp;
 
@@ -94,12 +93,11 @@ The Cause & Effect podcast, hosted by Johannes Schickling, features stories from
 
 ## Effect Website
 
-We redesigned and rebuilt the Effect website! [Check out the public repo](https://github.com/Effect-TS/website). 
+We redesigned and rebuilt the Effect website! [Check out the public repo](https://github.com/Effect-TS/website).
 
-The docs are still for Effect v3 for now. This new website gives us the foundation to build a much better documentation experience for Effect v4, which we'll continue developing as we move toward the release. 
+The docs are still for Effect v3 for now. This new website gives us the foundation to build a much better documentation experience for Effect v4, which we'll continue developing as we move toward the release.
 
-  <Tweet id="2080653731259920445" />
-
+<Tweet id="2080653731259920445" />
 
 &nbsp;
 
@@ -123,7 +121,7 @@ The docs are still for Effect v3 for now. This new website gives us the foundati
 
 &nbsp;
 
-- Building Loops for the Real World, by Kyle Mistele (HumanLayer) at  AI Engineer World's Fair 2026.
+- Building Loops for the Real World, by Kyle Mistele (HumanLayer) at AI Engineer World's Fair 2026.
 
   <Tweet id="2080036507558298070" />
 
@@ -133,14 +131,14 @@ The docs are still for Effect v3 for now. This new website gives us the foundati
 
 &nbsp;
 
- <YouTube
+<YouTube
   id="https://www.youtube.com/embed/jgfS7s0XN6E?si=_SNH-Swgco4fEV3d"
   title="Effect.ts + GraphQL | Using Effect RPC to Serve GraphQL"
 />
 
 &nbsp;
 
-- Experimental project by Sandro Maglione. 
+- Experimental project by Sandro Maglione.
 
   <Tweet id="2079976425885475060" />
 
@@ -154,7 +152,7 @@ The docs are still for Effect v3 for now. This new website gives us the foundati
 
 - Effect v4 RC Prep, CLI Wizard Mode, HTTP API Patterns | Effect Office Hours 38 🔥
 
- <YouTube
+<YouTube
   id="https://www.youtube.com/embed/jgfS7s0XN6E?si=_SNH-Swgco4fEV3d"
   title="Effect Office Hours 38 🔥"
 />
@@ -180,7 +178,6 @@ New this week: **Datapizza** is hiring a Software Engineer in Milan, Italy.
 
 _Disclaimer: Please note that these job postings are shared for informational purposes, and we encourage applicants to verify details directly with the hiring companies._
 
-
 &nbsp;
 
 ## Effect Merch Store
@@ -189,8 +186,8 @@ The [Effect Merch Store](https://effect.website/merch) offers a selection of Eff
 
 <Tweet id="1868605126862385238" />
 
-
 &nbsp;
+
 ## Closing Notes
 
 That's all for this week. Thank you for being a vital part of our community. Your feedback is highly valued as we fine-tune this format. Feel free to share your thoughts, and we'll do our best to tailor it to the needs of our community.

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -170,7 +170,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3)
             class="prose prose-zinc dark:prose-invert prose-sm md:prose-base max-w-none
                    prose-headings:font-semibold prose-headings:tracking-tight
                    prose-a:text-sky-400 prose-a:no-underline [&_a:hover]:underline
-                   prose-code:text-zinc-200 prose-code:bg-zinc-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
+                   prose-code:bg-zinc-100 prose-code:text-zinc-700 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
                    prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-700"
           >
             <h1 class="!mt-0">{entry.data.title}</h1>

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -170,7 +170,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3)
             class="prose prose-zinc dark:prose-invert prose-sm md:prose-base max-w-none
                    prose-headings:font-semibold prose-headings:tracking-tight
                    prose-a:text-sky-400 prose-a:no-underline [&_a:hover]:underline
-                   prose-code:bg-zinc-100 prose-code:text-zinc-700 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
+                   prose-code:bg-zinc-200 prose-code:text-zinc-700 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
                    prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-700"
           >
             <h1 class="!mt-0">{entry.data.title}</h1>


### PR DESCRIPTION
Fixes the theme colour mismatch in inline code boxes
(before & after)

<img width="882" height="541" alt="image" src="https://github.com/user-attachments/assets/0bf0c218-8d71-4697-a5e7-53633315586c" />
<img width="873" height="562" alt="image" src="https://github.com/user-attachments/assets/86715d27-25fc-48b9-b3f2-6eac51521f0c" />




## Summary

- use a lighter inline-code background in the docs light theme
- preserve the existing dark-theme inline-code colors

## Testing

- `pnpm check`
- `pnpm exec prettier --check "src/pages/docs/[...slug].astro"`