### PR TITLE
fix: urls pointing to main instead of v3 branch

### DIFF
--- a/src/content/blog/effect-2025-year-in-review.mdx
+++ b/src/content/blog/effect-2025-year-in-review.mdx
@@ -40,7 +40,7 @@ This year, Mattia Manzati and Kit Langton joined the team, strengthening both ec
 
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0), bringing first-class abstractions for AI-native and agent-based systems
 - [Developer tooling](https://effect.website/docs/getting-started/devtools/): Effect LSP, VS Code / Cursor Extension.
-- [effect/workflow (alpha)](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) — durable, orchestrated workflows built on Effect’s runtime
+- [effect/workflow (alpha)](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) — durable, orchestrated workflows built on Effect’s runtime
 - [effect-atom](https://github.com/tim-smart/effect-atom) — a reactive state management library for Effect.
 
 &nbsp;

--- a/src/content/blog/effect-v4Beta-june-recap.mdx
+++ b/src/content/blog/effect-v4Beta-june-recap.mdx
@@ -17,7 +17,7 @@ June brought another round of updates to the Effect v4 beta.
 
 This month’s work included new rate limiting capabilities, Schema improvements, SQL and CLI updates, plus a series of fixes across OpenTelemetry, HTTP, RPC, and core.
 
-Here's everything that landed in [`effect-smol`](https://github.com/Effect-TS/effect-smol) during June.
+Here's everything that landed in [`effect`](https://github.com/Effect-TS/effect) during June.
 
 &nbsp;
 

--- a/src/content/blog/effect-v4Beta-launch-to-may-recap.mdx
+++ b/src/content/blog/effect-v4Beta-launch-to-may-recap.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components"
 
 import bundleSizeVizSrc from "./releases/effect/4.0-beta/video/bundle-size-viz.mp4"
 
-Effect v4 Beta launched February 18, 2026. Since then, the team has been shipping at a relentless pace inside the [`effect-smol` repository](https://github.com/Effect-TS/effect-smol).
+Effect v4 Beta launched February 18, 2026. Since then, the team has been shipping at a relentless pace inside the [`effect` repository](https://github.com/Effect-TS/effect).
 
 If you've been following the weekly This Week In Effect summaries, you've seen each piece land individually. This post pulls it all together: what v4 set out to change, what has landed since launch, and where the beta has been moving over the past few months.
 
@@ -195,7 +195,7 @@ Added `availableShardGroups` to `ShardingConfig` to prevent advisory lock confli
 
 - **Removals.** Removed `Effect.Yieldable`, continuing the v4 API surface cleanup. Removed `Schema.Codec.ToAsserts`. Removed a duplicated `stringifyCircular` utility. Removed rulesync and cleanup patterns. Renamed `dtslint` directories to `typetest`.
 
-- **Migration tooling.** Previous API names are being added to migration maps for smoother upgrading. Two migration guides are available: the [v3 to v4 Migration Guide](https://github.com/Effect-TS/effect-smol/blob/main/MIGRATION.md) and the [Schema v4 Migration Guide](https://github.com/Effect-TS/effect-smol/blob/main/packages/effect/SCHEMA.md).
+- **Migration tooling.** Previous API names are being added to migration maps for smoother upgrading. Two migration guides are available: the [v3 to v4 Migration Guide](https://github.com/Effect-TS/effect/blob/main/MIGRATION.md) and the [Schema v4 Migration Guide](https://github.com/Effect-TS/effect/blob/main/packages/effect/SCHEMA.md).
 
 &nbsp;
 

--- a/src/content/blog/releases/effect/3.1.mdx
+++ b/src/content/blog/releases/effect/3.1.mdx
@@ -103,6 +103,6 @@ type MutableValues<A> = Types.DeepMutable<Values<A>>
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.10.mdx
+++ b/src/content/blog/releases/effect/3.10.mdx
@@ -96,7 +96,7 @@ The `HttpApi` modules have undergone a number of improvements:
 - Error schemas now support `HttpApiSchema` encoding apis
 - `toWebHandler` has been simplified
 
-For more information, see the [README](https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md#http-api).
+For more information, see the [README](https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md#http-api).
 
 ## TSubscriptionRef
 
@@ -146,6 +146,6 @@ Effect.gen(function* () {
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.11.mdx
+++ b/src/content/blog/releases/effect/3.11.mdx
@@ -309,6 +309,6 @@ Hi!
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.12.mdx
+++ b/src/content/blog/releases/effect/3.12.mdx
@@ -99,6 +99,6 @@ Some new schema types & combinators have been added:
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.13.mdx
+++ b/src/content/blog/releases/effect/3.13.mdx
@@ -212,6 +212,6 @@ const UpdateMyService = RequiresMyService.pipe(
 - `Trie` type variance has been relaxed to be covariant.
 - `Differ` now implements the `Pipeable` interface.
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.14.mdx
+++ b/src/content/blog/releases/effect/3.14.mdx
@@ -70,7 +70,7 @@ Effect.gen(function* () {
 
 The `@effect/rpc` package has undergone a refactor to improve the ergonomics of the API, and to make it more modular.
 
-To read more about the changes, take a look at the [README](https://github.com/Effect-TS/effect/blob/main/packages/rpc/README.md).
+To read more about the changes, take a look at the [README](https://github.com/Effect-TS/effect/blob/v3/packages/rpc/README.md).
 
 ## Effect.linkSpanCurrent
 
@@ -160,6 +160,6 @@ console.log(Effect.runSync(result))
 - `DateTime.nowAsDate` was added, which returns the current time as a JS `Date` object.
 - `HashMap.every` was added, which checks if every entry in the `HashMap` satisfies a predicate.
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.15.mdx
+++ b/src/content/blog/releases/effect/3.15.mdx
@@ -149,6 +149,6 @@ Effect.void.pipe(
 - `Cause.isTimeoutException` is now available
 - `Function.apply` now accepts mulitple arguments
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.16.mdx
+++ b/src/content/blog/releases/effect/3.16.mdx
@@ -181,6 +181,6 @@ const dbPort: Config.Config<Port> = Config.number("DB_PORT").pipe(
 - `HashMap.hasBy` - check if a HashMap contains a member using a predicate
 - `BigDecimal` rounding apis have been added
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.17.mdx
+++ b/src/content/blog/releases/effect/3.17.mdx
@@ -87,6 +87,6 @@ const entries: Array<["a" | "b", string | number]> = Struct.entries(value)
 - Schedule `CurrentIterationMetadata` now includes the schedule output.
 - Effect runtime version mismatches are now warnings instead of errors.
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.18.mdx
+++ b/src/content/blog/releases/effect/3.18.mdx
@@ -75,6 +75,6 @@ export const program = effectHandler(MyUseCase)
 
 - `resize` method has been added to `Effect.Semaphore`, allowing dynamic adjustment of a semaphore's permits.
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.19.mdx
+++ b/src/content/blog/releases/effect/3.19.mdx
@@ -80,6 +80,6 @@ const myfn = Effect.fn("myfn")(function* (n: number): Effect.fn.Return<string> {
 - `Graph` module updates have been backported from Effect v4
 - `@effect/sql-pg` now uses the "pg" npm library as its backend
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.2.mdx
+++ b/src/content/blog/releases/effect/3.2.mdx
@@ -114,6 +114,6 @@ pipe(
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.3.mdx
+++ b/src/content/blog/releases/effect/3.3.mdx
@@ -133,6 +133,6 @@ The following type guards have been added to the `Predicate` module:
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.4.mdx
+++ b/src/content/blog/releases/effect/3.4.mdx
@@ -80,6 +80,6 @@ const last = Chunk.lastNonEmpty(Chunk.of(1))
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.5.mdx
+++ b/src/content/blog/releases/effect/3.5.mdx
@@ -171,6 +171,6 @@ Stream.fromSchedule(Schedule.spaced(1000)).pipe(
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.6.mdx
+++ b/src/content/blog/releases/effect/3.6.mdx
@@ -155,6 +155,6 @@ Some new lifetime hook apis have been added to the `Stream` module:
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.7.mdx
+++ b/src/content/blog/releases/effect/3.7.mdx
@@ -21,7 +21,7 @@ These modules are still experimental and subject to change, so give them a try
 and post your feedback on the [Effect Discord](https://discord.gg/effect-ts).
 
 For more infomation see the README for the `@effect/platform` package:<br />
-https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md
+https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md
 
 ## Effect.bindAll
 
@@ -134,6 +134,6 @@ Effect.forEach([1, 2, 3], (n) => Effect.succeed(n), {
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.8.mdx
+++ b/src/content/blog/releases/effect/3.8.mdx
@@ -279,6 +279,6 @@ Some new apis for converting between a `Duration` and it's corresponding parts h
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/3.9.mdx
+++ b/src/content/blog/releases/effect/3.9.mdx
@@ -119,6 +119,6 @@ assert.deepStrictEqual(result, [1, 2, 3, 0, 0, 0])
 
 ## Other changes
 
-There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md).
+There were several other smaller changes made. Take a look through the CHANGELOG to see them all: [CHANGELOG](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md).
 
 Don't forget to join our [Discord Community](https://discord.gg/effect-ts) to follow the last updates and discuss every tiny detail!

--- a/src/content/blog/releases/effect/4.0-beta.mdx
+++ b/src/content/blog/releases/effect/4.0-beta.mdx
@@ -128,11 +128,11 @@ The contract is simple:
 - Modules outside `unstable/` follow strict semver — no breaking changes until the next major version
 - As unstable modules mature, they graduate into the top-level `effect/*` namespace
 
-v4 ships with [17 unstable modules](https://github.com/Effect-TS/effect-smol/tree/main/packages/effect/src/unstable) covering AI, HTTP, Schema, SQL, RPC, CLI, workflows, clustering, and more.
+v4 ships with [17 unstable modules](https://github.com/Effect-TS/effect/tree/main/packages/effect/src/unstable) covering AI, HTTP, Schema, SQL, RPC, CLI, workflows, clustering, and more.
 
 ## The beta phase
 
-The v4 codebase lives in the [Effect-TS/effect-smol](https://github.com/Effect-TS/effect-smol) repository. Issues, pull requests, and discussions related to v4 should be directed there.
+The v4 codebase lives in the [Effect-TS/effect](https://github.com/Effect-TS/effect) repository. Issues, pull requests, and discussions related to v4 should be directed there.
 
 **This is a beta.** We'll iterate quickly, and beta releases may include breaking changes. APIs will evolve as we incorporate real-world feedback and refine the design, and just like before, we will document changes in each release in the package changelog.
 
@@ -152,14 +152,14 @@ If you're coming from Effect v3, the core programming model — `Effect`, `Layer
 
 Two migration guides are available:
 
-- [**v3 to v4 Migration Guide**](https://github.com/Effect-TS/effect-smol/blob/main/MIGRATION.md) — covers the overall transition
-- [**Schema v4 Migration Guide**](https://github.com/Effect-TS/effect-smol/blob/main/packages/effect/SCHEMA.md) — covers the Schema rewrite in detail
+- [**v3 to v4 Migration Guide**](https://github.com/Effect-TS/effect/blob/main/MIGRATION.md) — covers the overall transition
+- [**Schema v4 Migration Guide**](https://github.com/Effect-TS/effect/blob/main/packages/effect/SCHEMA.md) — covers the Schema rewrite in detail
 
 We're also building migration tooling: codemods for renamings, AI-assisted migration skills, and more. We prioritized getting the release into your hands over delaying the beta to build out migration tooling. These tools will follow.
 
 ## Try it now
 
-Port a project, a module, or even just a file, and tell us how it goes. When you hit a bug, a confusing API, a missing feature, or something that just doesn't feel right, [file an issue on effect-smol](https://github.com/Effect-TS/effect-smol/issues). Reproduction steps, code snippets, and descriptions of what you expected vs. what happened all help us move faster.
+Port a project, a module, or even just a file, and tell us how it goes. When you hit a bug, a confusing API, a missing feature, or something that just doesn't feel right, [file an issue on effect](https://github.com/Effect-TS/effect/issues). Reproduction steps, code snippets, and descriptions of what you expected vs. what happened all help us move faster.
 
 Not ready to migrate? Testing the beta against your existing codebase and reporting what breaks is just as valuable. Even "I tried to upgrade and here's what didn't work" gives us the signal we need.
 

--- a/src/content/blog/this-week-in-effect/100/index.mdx
+++ b/src/content/blog/this-week-in-effect/100/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5980+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/101/index.mdx
+++ b/src/content/blog/this-week-in-effect/101/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 6030+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/102/index.mdx
+++ b/src/content/blog/this-week-in-effect/102/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6070+ community members on [Discord](https://discord.gg/effect-ts).
 - 13k 🌟 stars on [GitHub](https://github.com/Effect-TS/effect).
 

--- a/src/content/blog/this-week-in-effect/103/index.mdx
+++ b/src/content/blog/this-week-in-effect/103/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6080+ community members on [Discord](https://discord.gg/effect-ts).
 - 13k 🌟 stars on [GitHub](https://github.com/Effect-TS/effect).
 

--- a/src/content/blog/this-week-in-effect/104/index.mdx
+++ b/src/content/blog/this-week-in-effect/104/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6100+ community members on [Discord](https://discord.gg/effect-ts).
 - 13k 🌟 stars on [GitHub](https://github.com/Effect-TS/effect).
 

--- a/src/content/blog/this-week-in-effect/105/index.mdx
+++ b/src/content/blog/this-week-in-effect/105/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6100+ community members on [Discord](https://discord.gg/effect-ts).
 - 13k 🌟 stars on [GitHub](https://github.com/Effect-TS/effect).
 

--- a/src/content/blog/this-week-in-effect/106/index.mdx
+++ b/src/content/blog/this-week-in-effect/106/index.mdx
@@ -72,7 +72,7 @@ Here are all the technical changes from the past week.
 
 ## Community Highlights
 
-Thanks for the incredible energy around the Effect v4 beta launch. Let us know if you have any [feedback](https://github.com/Effect-TS/effect-smol/issues).
+Thanks for the incredible energy around the Effect v4 beta launch. Let us know if you have any [feedback](https://github.com/Effect-TS/effect/issues).
 
 <Tweet id="2024464958499455091" />
 

--- a/src/content/blog/this-week-in-effect/106/index.mdx
+++ b/src/content/blog/this-week-in-effect/106/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6100+ community members on [Discord](https://discord.gg/effect-ts).
 - 13k 🌟 stars on [GitHub](https://github.com/Effect-TS/effect).
 

--- a/src/content/blog/this-week-in-effect/107/index.mdx
+++ b/src/content/blog/this-week-in-effect/107/index.mdx
@@ -46,7 +46,7 @@ The v4 beta has been evolving rapidly since launch — here are the most notable
 - **OpenAPI & HTTP fixes**: multipart file upload schema fixed in OpenAI and OpenAI JSON schemas correctly transformed for AI integrations.
 - **CLI bug fix**: resolved global flag handling in mixed CLI contexts.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/107/index.mdx
+++ b/src/content/blog/this-week-in-effect/107/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6130+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/108/index.mdx
+++ b/src/content/blog/this-week-in-effect/108/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6140+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/108/index.mdx
+++ b/src/content/blog/this-week-in-effect/108/index.mdx
@@ -49,7 +49,7 @@ The v4 beta keeps moving fast. Here are the most notable changes that landed in 
 
 - **Bug fixes & internals**: Fixed `Effect.forkScoped` Scope requirements, corrected `SqlSchema findAll/findNonEmpty` request input typing, exposed `fallback` parameter in `Effect.catchTags`, and added `Scheduler.PreventSchedulerYield` reference.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/109/index.mdx
+++ b/src/content/blog/this-week-in-effect/109/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6200+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/109/index.mdx
+++ b/src/content/blog/this-week-in-effect/109/index.mdx
@@ -49,7 +49,7 @@ Here are the most notable changes that landed in `effect-smol`.
 
 - **Bug fixes & internals**: Fixed `Cause.hasInterruptsOnly` returning `false` for empty causes, fixed `consolePretty` ignoring explicit colors in non-TTY environments, made `HttpClientResponse` pipeable, preserved default logger message item ordering when logging a `Cause`, fixed `Ndjson` `Uint8Array` typing regression, and added a `message` option to `Effect.ignore` and `Effect.ignoreCause`.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/110/index.mdx
+++ b/src/content/blog/this-week-in-effect/110/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6220+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/110/index.mdx
+++ b/src/content/blog/this-week-in-effect/110/index.mdx
@@ -49,7 +49,7 @@ Here are the main changes that landed in `effect-smol`.
 
 - **Bug fixes & internals**: Fixed `Stream.scanEffect` hanging behavior, made `Layer.mock` work with `Stream` and `Channel`, fixed `Tool.make` type and runtime behavior when parameters are not provided, aligned CLI help description columns for long flags, added `Effect.acquireRelease` release dependency support, and fixed JSDoc wording for `Effect.catch`.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/111/index.mdx
+++ b/src/content/blog/this-week-in-effect/111/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6220+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/111/index.mdx
+++ b/src/content/blog/this-week-in-effect/111/index.mdx
@@ -47,7 +47,7 @@ Here are the main changes that landed in `effect-smol`.
 - **PostgreSQL & runtime**: Added a dedicated PG connection for `LISTEN`, switched to `pg_notify` instead of raw `NOTIFY` in `PgClient`, cleaned up `sql-pg` constructors and layers, fixed `Unify.unify` for Effect unions, flushed devtools queued messages on teardown, and tracked `ManagedRuntime` fibers in a scope.
 - **Bug fixes & internals**: Fixed `Schedule.fixed` immediate catch-up for long-running iterations, re-exported core `ServiceMap` references in `effect/References`, fixed `Queue.takeN` example, fixed metro bundler issues, allowed `ServiceMap.Key` to be covariant, and improved `Prompt.select`/`multiSelect` highlight text color.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/112/index.mdx
+++ b/src/content/blog/this-week-in-effect/112/index.mdx
@@ -51,7 +51,7 @@ Here are the main changes that landed in `effect-smol`.
 
 - **Platform & internals**: Added child process `unref` support, cleaned up `ShardId`, removed rulesync and cleanup patterns, and renamed `dtslint` directories to `typetest`.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/112/index.mdx
+++ b/src/content/blog/this-week-in-effect/112/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6230+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/113/index.mdx
+++ b/src/content/blog/this-week-in-effect/113/index.mdx
@@ -55,7 +55,7 @@ Here are the main changes that landed in `effect-smol`:
 
 - **PostgreSQL & internals**: Guarded transaction acquire failures in `PgClient.fromPool`, returned resolvers directly from `SqlModel.makeResolvers`, added `KeyValueStore.layerSql`, and made `Unify.unify` work with the `Layer` module.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/113/index.mdx
+++ b/src/content/blog/this-week-in-effect/113/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6250+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/114/index.mdx
+++ b/src/content/blog/this-week-in-effect/114/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6270+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/114/index.mdx
+++ b/src/content/blog/this-week-in-effect/114/index.mdx
@@ -55,7 +55,7 @@ Here are the main changes that landed in `effect-smol`:
 
 - **Internals**: Fixed SIGINT listener not being removed until fiber exit, updated dependencies, and cleaned up `AGENTS.md`.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/115/index.mdx
+++ b/src/content/blog/this-week-in-effect/115/index.mdx
@@ -55,7 +55,7 @@ The v4 beta had another packed week, with new packages, workflow reliability fix
 
 - **SQL & internals**: Disabled SQL traces for `EventLog` and `RunnerStorage`, added `makeMsgPack` for configurable `msgpackr` options, removed use of bigint literals, fixed the `isNullish()` type predicate, and fixed `TestClock` nanoseconds flooring before `BigInt` conversion.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/115/index.mdx
+++ b/src/content/blog/this-week-in-effect/115/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6290+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/116/index.mdx
+++ b/src/content/blog/this-week-in-effect/116/index.mdx
@@ -52,7 +52,7 @@ Here are the most notable changes that landed in `effect-smol`.
 
 - **Platform & internals**: Allowed `Duration.Input` with accessors for more ergonomic duration handling, and optimized binary array generation from streams to reduce unnecessary copying.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/116/index.mdx
+++ b/src/content/blog/this-week-in-effect/116/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6300+ community members on [Discord](https://discord.gg/effect-ts).
 - 14k GitHub stars! 🌟
 

--- a/src/content/blog/this-week-in-effect/117/index.mdx
+++ b/src/content/blog/this-week-in-effect/117/index.mdx
@@ -56,7 +56,7 @@ A steady week for the v4 beta, with new testing utilities, schema additions, and
 
 - **Platform**: Allowed `null` for Kubernetes condition `lastTransitionTime` to handle optional fields in K8s manifests.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/117/index.mdx
+++ b/src/content/blog/this-week-in-effect/117/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6330+ community members on [Discord](https://discord.gg/effect-ts).
 - 14k GitHub stars! 🌟
 

--- a/src/content/blog/this-week-in-effect/118/index.mdx
+++ b/src/content/blog/this-week-in-effect/118/index.mdx
@@ -64,7 +64,7 @@ Significant Schema ergonomics improvements, a new durable module port, and conti
 
 - **Removals**: Removed `Effect.Yieldable`, continuing the v4 API surface cleanup.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/118/index.mdx
+++ b/src/content/blog/this-week-in-effect/118/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6380+ community members on [Discord](https://discord.gg/effect-ts).
 - 14k GitHub stars! 🌟
 

--- a/src/content/blog/this-week-in-effect/119/index.mdx
+++ b/src/content/blog/this-week-in-effect/119/index.mdx
@@ -57,7 +57,7 @@ This week, Effect v4 Beta got a major push on documentation quality, new stream 
 
 - **SQL & Sharding**: Added support for `.mts` and `.mjs` SQL migration files, and added `availableShardGroups` to `ShardingConfig` to prevent advisory lock conflicts.
 
-You can follow the full changelog directly in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+You can follow the full changelog directly in the [effect repository](https://github.com/Effect-TS/effect).
 
 &nbsp;
 

--- a/src/content/blog/this-week-in-effect/119/index.mdx
+++ b/src/content/blog/this-week-in-effect/119/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation and our guide for
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6410+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/120/index.mdx
+++ b/src/content/blog/this-week-in-effect/120/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation and our guide for
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6450+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/120/index.mdx
+++ b/src/content/blog/this-week-in-effect/120/index.mdx
@@ -57,7 +57,7 @@ The v4 beta closed out May with a strong week across HTTP security, reactivity, 
 
 - **Documentation**: Continued the JSDoc quality push with improvements across `Effect` core APIs, a new `Schedule` cookbook, and corrected misleading API docs.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/121/index.mdx
+++ b/src/content/blog/this-week-in-effect/121/index.mdx
@@ -55,7 +55,7 @@ The v4 beta wrapped up May and opened June with a focused week on observability,
 
 - **Documentation**: Refined JSDoc usage guidance, and clarified `Schema.Class` equality docs.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/121/index.mdx
+++ b/src/content/blog/this-week-in-effect/121/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation and our guide for
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6460+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/122/index.mdx
+++ b/src/content/blog/this-week-in-effect/122/index.mdx
@@ -61,7 +61,7 @@ The v4 beta had a well-rounded week, with important bug fixes across Schema, tre
 
 - **Documentation**: Clarified `Effect.fn` and `fnUntraced` usage, clarified `Model.GeneratedByDb` variants, fixed the MCP example in `effect` docs, corrected JSDoc on `Workflow.poll` and `WorkflowEngine.poll`, and continued the module JSDoc refactor.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/122/index.mdx
+++ b/src/content/blog/this-week-in-effect/122/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation and our guide for
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6470+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/123/index.mdx
+++ b/src/content/blog/this-week-in-effect/123/index.mdx
@@ -67,7 +67,7 @@ The v4 beta had quite an active week, with streaming support landing in HttpApi,
 
 - **Documentation**: Added JSDoc function signature extraction, normalized JSDoc example titles across the codebase, added `DateTime` AI docs, and updated generated AI documentation.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/123/index.mdx
+++ b/src/content/blog/this-week-in-effect/123/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation and our guide for
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6470+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/124/index.mdx
+++ b/src/content/blog/this-week-in-effect/124/index.mdx
@@ -63,7 +63,7 @@ The v4 beta had a packed final week of June, with a new adaptive rate limiter, S
 
 - **Documentation**: Refactored the `Schedule` cookbook, clarified `Redacted` schema migration docs, and added an unused internal export lint rule.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/124/index.mdx
+++ b/src/content/blog/this-week-in-effect/124/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation and our guide for
 
 - [Effect v4 Beta](https://effect.website/blog/releases/effect/40-beta/) Release! 🚀
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - 6480+ community members on [Discord](https://discord.gg/effect-ts).
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/125/index.mdx
+++ b/src/content/blog/this-week-in-effect/125/index.mdx
@@ -53,7 +53,7 @@ The v4 beta entered July with a focus on correctness fixes, URL API refinements,
 
 - **AI documentation expansion**: Added `Schema` and `Predicate` introductions to the AI docs, and rearranged the Schedule AI docs section for better discoverability.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/126/index.mdx
+++ b/src/content/blog/this-week-in-effect/126/index.mdx
@@ -65,7 +65,7 @@ The v4 beta had one of its busiest weeks yet, a sweeping `Schedule` API rework, 
 
 - **HTTP**: Fixed `HttpApi` runtime shape, and allowed additional `HttpApiClient` options.
 
-Full changelog in the [effect-smol repository](https://github.com/Effect-TS/effect-smol).
+Full changelog in the [effect repository](https://github.com/Effect-TS/effect).
 
 ---
 

--- a/src/content/blog/this-week-in-effect/13/index.mdx
+++ b/src/content/blog/this-week-in-effect/13/index.mdx
@@ -44,7 +44,7 @@ Now, back to business!
 
 ## Technology
 
-[Effect 3.1](https://effect.website/blog/effect-3.1) has been released. Be sure to read the full release post edited by [Tim Smart](https://twitter.com/tim_smart) and the related [changelog](https://github.com/Effect-TS/effect/blob/main/packages/effect/CHANGELOG.md) to stay updated about all latest features and improvements.
+[Effect 3.1](https://effect.website/blog/effect-3.1) has been released. Be sure to read the full release post edited by [Tim Smart](https://twitter.com/tim_smart) and the related [changelog](https://github.com/Effect-TS/effect/blob/v3/packages/effect/CHANGELOG.md) to stay updated about all latest features and improvements.
 
 Below you can find all the changes that occurred last week (PRs included in Effect 3.1 release will not be listed).
 

--- a/src/content/blog/this-week-in-effect/69/index.mdx
+++ b/src/content/blog/this-week-in-effect/69/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 Recent major updates:
 
 - Effect Days 2025: [Simplifying Forms with Effect](https://youtu.be/RieDcO_LJik) & [Incremental Adoption of Effect](https://youtu.be/LEiNtsMMo8c)
-- Build and run durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Build and run durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4300+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/70/index.mdx
+++ b/src/content/blog/this-week-in-effect/70/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 Recent major updates:
 
 - Effect Days 2025: [Effective Pragmatism](https://www.youtube.com/watch?v=D1uf-uAnxus) and [Next-gen DevTools for Effect](https://www.youtube.com/watch?v=ZCHNLS8e0os).
-- Build and run durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Build and run durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4360+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/71/index.mdx
+++ b/src/content/blog/this-week-in-effect/71/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 Recent major updates:
 
 - Effect Days 2025: [How DXOS uses Effect to transform AI](https://www.youtube.com/watch?v=e0ehxHEcaLY) and [How Expand.ai turn the Internet into a Database with Effect](https://www.youtube.com/watch?v=0C20pfZi6jE).
-- Build and run durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Build and run durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4400+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/72/index.mdx
+++ b/src/content/blog/this-week-in-effect/72/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 Recent major updates:
 
 - Cause & Effect Podcast with David Golightly: [A Voice AI Orchestration Layer with Effect & TypeScript](https://www.youtube.com/watch?v=x2bUuOZ-htU).
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4500+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/73/index.mdx
+++ b/src/content/blog/this-week-in-effect/73/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - Effect reached [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4640+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/74/index.mdx
+++ b/src/content/blog/this-week-in-effect/74/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - Effect crossed [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4750+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/75/index.mdx
+++ b/src/content/blog/this-week-in-effect/75/index.mdx
@@ -29,7 +29,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - Effect crossed [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4850+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/76/index.mdx
+++ b/src/content/blog/this-week-in-effect/76/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
 - Effect crossed [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md).
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md).
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4900+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/77/index.mdx
+++ b/src/content/blog/this-week-in-effect/77/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - Effect crossed [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 4930+ members!
 

--- a/src/content/blog/this-week-in-effect/78/index.mdx
+++ b/src/content/blog/this-week-in-effect/78/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - Effect crossed [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5000+ members!
 

--- a/src/content/blog/this-week-in-effect/79/index.mdx
+++ b/src/content/blog/this-week-in-effect/79/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - Effect crossed [10K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5050+ members!
 

--- a/src/content/blog/this-week-in-effect/80/index.mdx
+++ b/src/content/blog/this-week-in-effect/80/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - Effect crossed [11K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5100+ members!
 

--- a/src/content/blog/this-week-in-effect/81/index.mdx
+++ b/src/content/blog/this-week-in-effect/81/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5170+ members!
 - Effect crossed [11K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 

--- a/src/content/blog/this-week-in-effect/82/index.mdx
+++ b/src/content/blog/this-week-in-effect/82/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5230+ members!
 - Effect crossed [11K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 

--- a/src/content/blog/this-week-in-effect/83/index.mdx
+++ b/src/content/blog/this-week-in-effect/83/index.mdx
@@ -29,8 +29,8 @@ To get started, below you’ll find links to our documentation as well as our gu
 **Recent major updates:**
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
-- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/main/packages/ai) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
+- Effect AI integration packages, [`@effect/ai`](https://github.com/Effect-TS/effect/tree/v3/packages/ai) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5280+ members!
 - Effect crossed [11K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 

--- a/src/content/blog/this-week-in-effect/84/index.mdx
+++ b/src/content/blog/this-week-in-effect/84/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5290+ members!
 - Effect crossed [11K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 

--- a/src/content/blog/this-week-in-effect/85/index.mdx
+++ b/src/content/blog/this-week-in-effect/85/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.17](https://effect.website/blog/releases/effect/317) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5310+ members!
 - Effect crossed [11K Stars on GitHub](https://github.com/Effect-TS/effect) 🌟.
 

--- a/src/content/blog/this-week-in-effect/86/index.mdx
+++ b/src/content/blog/this-week-in-effect/86/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.18](https://effect.website/blog/releases/effect/318) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5390+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/87/index.mdx
+++ b/src/content/blog/this-week-in-effect/87/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.18](https://effect.website/blog/releases/effect/318) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5400+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/88/index.mdx
+++ b/src/content/blog/this-week-in-effect/88/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.18](https://effect.website/blog/releases/effect/318) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5400+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/89/index.mdx
+++ b/src/content/blog/this-week-in-effect/89/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.18](https://effect.website/blog/releases/effect/318) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5480+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/90/index.mdx
+++ b/src/content/blog/this-week-in-effect/90/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.18](https://effect.website/blog/releases/effect/318) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5510+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/91/index.mdx
+++ b/src/content/blog/this-week-in-effect/91/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5510+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/92/index.mdx
+++ b/src/content/blog/this-week-in-effect/92/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5570+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/93/index.mdx
+++ b/src/content/blog/this-week-in-effect/93/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5620+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/94/index.mdx
+++ b/src/content/blog/this-week-in-effect/94/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5660+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/95/index.mdx
+++ b/src/content/blog/this-week-in-effect/95/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5800+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/96/index.mdx
+++ b/src/content/blog/this-week-in-effect/96/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5850+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/97/index.mdx
+++ b/src/content/blog/this-week-in-effect/97/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5900+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/98/index.mdx
+++ b/src/content/blog/this-week-in-effect/98/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5920+ members!
 
 &nbsp;

--- a/src/content/blog/this-week-in-effect/99/index.mdx
+++ b/src/content/blog/this-week-in-effect/99/index.mdx
@@ -30,7 +30,7 @@ To get started, below you’ll find links to our documentation as well as our gu
 
 - [Effect 3.19](https://effect.website/blog/releases/effect/319) Release.
 - [Effect AI SDK](https://github.com/Effect-TS/effect/releases/tag/%40effect%2Fai%400.27.0) Release.
-- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/main/packages/workflow/README.md) - currently in alpha.
+- Durable workflows in TypeScript with [`@effect/workflow`](https://github.com/Effect-TS/effect/blob/v3/packages/workflow/README.md) - currently in alpha.
 - The [Effect community](https://discord.gg/effect-ts) on Discord reached 5920+ members!
 
 &nbsp;

--- a/src/content/docs/v3/additional-resources/api-reference.mdx
+++ b/src/content/docs/v3/additional-resources/api-reference.mdx
@@ -6,9 +6,9 @@ sidebar:
 ---
 
 - [`effect`](https://effect-ts.github.io/effect/docs/effect)
-- [`@effect/cli`](https://effect-ts.github.io/effect/docs/cli) ([Getting Started](https://github.com/Effect-TS/effect/blob/main/packages/cli/README.md))
+- [`@effect/cli`](https://effect-ts.github.io/effect/docs/cli) ([Getting Started](https://github.com/Effect-TS/effect/blob/v3/packages/cli/README.md))
 - [`@effect/opentelemetry`](https://effect-ts.github.io/effect/docs/opentelemetry)
-- [`@effect/platform`](https://effect-ts.github.io/effect/docs/platform) ([Experimental Features](https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md))
-- [`@effect/printer`](https://effect-ts.github.io/effect/docs/printer) ([Getting Started](https://github.com/Effect-TS/effect/blob/main/packages/printer/README.md))
-- [`@effect/rpc`](https://effect-ts.github.io/effect/docs/rpc) ([Getting Started](https://github.com/Effect-TS/effect/blob/main/packages/rpc/README.md))
-- [`@effect/typeclass`](https://effect-ts.github.io/effect/docs/typeclass) ([Getting Started](https://github.com/Effect-TS/effect/blob/main/packages/typeclass/README.md))
+- [`@effect/platform`](https://effect-ts.github.io/effect/docs/platform) ([Experimental Features](https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md))
+- [`@effect/printer`](https://effect-ts.github.io/effect/docs/printer) ([Getting Started](https://github.com/Effect-TS/effect/blob/v3/packages/printer/README.md))
+- [`@effect/rpc`](https://effect-ts.github.io/effect/docs/rpc) ([Getting Started](https://github.com/Effect-TS/effect/blob/v3/packages/rpc/README.md))
+- [`@effect/typeclass`](https://effect-ts.github.io/effect/docs/typeclass) ([Getting Started](https://github.com/Effect-TS/effect/blob/v3/packages/typeclass/README.md))

--- a/src/content/docs/v3/platform/introduction.mdx
+++ b/src/content/docs/v3/platform/introduction.mdx
@@ -36,15 +36,15 @@ The following modules are stable and their documentation is available on this we
 Some modules in `@effect/platform` are still in development or marked as experimental.
 These features are subject to change.
 
-| Module                                                                                               | Description                                     | Status                                      |
-| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------- |
-| [Http API](https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md#http-api)       | Provide a declarative way to define HTTP APIs.  | <Badge text="Unstable" variant="caution" /> |
-| [Http Client](https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md#http-client) | A client for making HTTP requests.              | <Badge text="Unstable" variant="caution" /> |
-| [Http Server](https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md#http-server) | A server for handling HTTP requests.            | <Badge text="Unstable" variant="caution" /> |
-| [Socket](https://effect-ts.github.io/effect/platform/Socket.ts.html)                                 | A module for socket-based communication.        | <Badge text="Unstable" variant="caution" /> |
-| [Worker](https://effect-ts.github.io/effect/platform/Worker.ts.html)                                 | A module for running tasks in separate workers. | <Badge text="Unstable" variant="caution" /> |
+| Module                                                                                             | Description                                     | Status                                      |
+| -------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------- |
+| [Http API](https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md#http-api)       | Provide a declarative way to define HTTP APIs.  | <Badge text="Unstable" variant="caution" /> |
+| [Http Client](https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md#http-client) | A client for making HTTP requests.              | <Badge text="Unstable" variant="caution" /> |
+| [Http Server](https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md#http-server) | A server for handling HTTP requests.            | <Badge text="Unstable" variant="caution" /> |
+| [Socket](https://effect-ts.github.io/effect/platform/Socket.ts.html)                               | A module for socket-based communication.        | <Badge text="Unstable" variant="caution" /> |
+| [Worker](https://effect-ts.github.io/effect/platform/Worker.ts.html)                               | A module for running tasks in separate workers. | <Badge text="Unstable" variant="caution" /> |
 
-For the most up-to-date documentation and details, please refer to the official [README](https://github.com/Effect-TS/effect/blob/main/packages/platform/README.md) of the package.
+For the most up-to-date documentation and details, please refer to the official [README](https://github.com/Effect-TS/effect/blob/v3/packages/platform/README.md) of the package.
 
 ## Installation
 


### PR DESCRIPTION
Fix all links that point to v3 in the repo and update references to `effect` when relevant.