### PR TITLE
ui: aside visual adjustments

### DIFF
--- a/src/components/docs/Aside.astro
+++ b/src/components/docs/Aside.astro
@@ -40,22 +40,32 @@ const Icon = iconMap[type]
 
 <style>
   .aside {
+    position: relative;
     border-radius: 0.375rem;
-    padding: 0.875rem 1.125rem 0.25rem;
+    padding: 1.12rem 1.125rem 0.25rem;
     margin-block: 1.5rem;
+  }
+
+  .aside::before {
+    position: absolute;
+    inset: 0;
+    border: 2px solid rgb(255 255 255 / 90%);
+    border-radius: inherit;
+    content: "";
+    mix-blend-mode: overlay;
+    pointer-events: none;
   }
 
   .aside-title {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-family: var(--font-mono);
+    font-family: var(--font-sans);
     font-size: 1rem;
     font-weight: 600;
-    line-height: 1.25rem;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    margin: 0 0 0.25rem;
+    line-height: 1.125rem;
+    letter-spacing: normal;
+    margin: 0;
   }
 
   .aside-title :global(svg) {

--- a/src/components/docs/Aside.astro
+++ b/src/components/docs/Aside.astro
@@ -52,9 +52,10 @@ const Icon = iconMap[type]
     font-family: var(--font-mono);
     font-size: 1rem;
     font-weight: 600;
+    line-height: 1.25rem;
     letter-spacing: 0.05em;
     text-transform: uppercase;
-    margin: 0 0 0.375rem;
+    margin: 0 0 0.25rem;
   }
 
   .aside-title :global(svg) {

--- a/src/components/docs/Aside.astro
+++ b/src/components/docs/Aside.astro
@@ -30,7 +30,7 @@ const Icon = iconMap[type]
 
 <aside class:list={["aside", `aside--${type}`]} aria-label={label}>
   <p class="aside-title" aria-hidden="true">
-    <Icon aria-hidden="true" size={14} />
+    <Icon aria-hidden="true" size={16} stroke-width={2.5} />
     {label}
   </p>
   <div class="aside-content">
@@ -41,21 +41,24 @@ const Icon = iconMap[type]
 <style>
   .aside {
     border-radius: 0.375rem;
-    border-left: 3px solid;
-    padding: 0.875rem 1.125rem;
+    padding: 0.875rem 1.125rem 0.25rem;
     margin-block: 1.5rem;
   }
 
   .aside-title {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 0.5rem;
     font-family: var(--font-mono);
-    font-size: 0.75rem;
+    font-size: 1rem;
     font-weight: 600;
     letter-spacing: 0.05em;
     text-transform: uppercase;
-    margin: 0 0 0.625rem;
+    margin: 0 0 0.375rem;
+  }
+
+  .aside-title :global(svg) {
+    transform: translateY(-1px);
   }
 
   .aside-content :global(> :first-child) {
@@ -67,7 +70,6 @@ const Icon = iconMap[type]
 
   .aside--note {
     background-color: color-mix(in srgb, #3b82f6 8%, transparent);
-    border-left-color: #3b82f6;
   }
   .aside--note .aside-title {
     color: #3b82f6;
@@ -75,7 +77,6 @@ const Icon = iconMap[type]
 
   .aside--tip {
     background-color: color-mix(in srgb, #10b981 8%, transparent);
-    border-left-color: #10b981;
   }
   .aside--tip .aside-title {
     color: #10b981;
@@ -83,7 +84,6 @@ const Icon = iconMap[type]
 
   .aside--caution {
     background-color: color-mix(in srgb, #f59e0b 8%, transparent);
-    border-left-color: #f59e0b;
   }
   .aside--caution .aside-title {
     color: #f59e0b;
@@ -91,7 +91,6 @@ const Icon = iconMap[type]
 
   .aside--danger {
     background-color: color-mix(in srgb, #ef4444 8%, transparent);
-    border-left-color: #ef4444;
   }
   .aside--danger .aside-title {
     color: #ef4444;

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -245,7 +245,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3)
             class="prose prose-zinc dark:prose-invert prose-sm md:prose-base max-w-none
                    prose-headings:font-semibold prose-headings:tracking-tight
                    prose-a:text-sky-400 prose-a:no-underline [&_a:hover]:underline
-                   prose-code:bg-zinc-200 prose-code:text-zinc-700 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
+                   prose-code:bg-black/10 prose-code:text-zinc-700 dark:prose-code:bg-white/10 dark:prose-code:text-zinc-200 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
                    prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-700"
           >
             <h1 class="!mt-0">{entry.data.title}</h1>


### PR DESCRIPTION
<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Remove the claude-esque accent, tighten up the padding/layout, align the icon and header, make the header text more legible

(before/after)
<img width="920" height="445" alt="image" src="https://github.com/user-attachments/assets/8cac36af-5d8f-4f00-99d4-9eb59bd98f6f" />
<img width="920" height="445" alt="image" src="https://github.com/user-attachments/assets/71ec5b84-7fed-4684-86e4-23d5d0dbac57" />

## Summary

- refresh docs asides with cleaner spacing and no left accent border
- improve title typography, icon sizing, weight, and alignment
- add a subtle overlay-blended border around asides
- use translucent inline-code backgrounds that blend with colored content

## Validation

- `pnpm lint`
- `pnpm fmt`
- `pnpm check`