### PR TITLE
fix: preserve visual effect controls

### DIFF
--- a/src/features/visual-effect/runtime/VisualEffectManager.ts
+++ b/src/features/visual-effect/runtime/VisualEffectManager.ts
@@ -204,13 +204,8 @@ export class VisualEffectManager extends Context.Service<
         start: Effect.fnUntraced(function* (example) {
           const startedAt = yield* DateTime.now
           const startedAtMillis = DateTime.toEpochMillis(startedAt)
-          const snapshotRegistry = AtomRegistry.make({
-            initialValues: example.controls.map(
-              (control) => [control.atom, registry.get(control.atom)] as const,
-            ),
-          })
           const snapshot = ControlSnapshot.of({
-            get: (atom) => snapshotRegistry.get(atom),
+            get: (atom) => registry.get(atom),
           })
           const notify = notifyForExample(example)
 


### PR DESCRIPTION
## Summary
- read visual effect controls from the active registry
- prevent control values from being evicted before execution
- preserve selected concurrency on first and subsequent runs

## Verification
- `pnpm check`
- `pnpm lint`
- Playwright: sequential/numbered/unbounded start 1/2/4 tasks on desktop and WebKit with a Chrome iOS user agent