### PR TITLE
Fix playground share requests

### DIFF
--- a/src/services/shorten/client.ts
+++ b/src/services/shorten/client.ts
@@ -16,8 +16,9 @@ export class ShortenClient extends Context.Service<
   static readonly layer = Layer.effect(ShortenClient, RpcClient.make(ShortenRpcs)).pipe(
     Layer.provide(
       RpcClient.layerProtocolHttp({
-        url: "/api/rpc",
-        transformClient: HttpClient.mapRequest(HttpClientRequest.setUrl("/api/rpc")),
+        // The RPC transport posts to an empty path, which `url` would join as `/api/rpc/`.
+        url: "",
+        transformClient: HttpClient.mapRequest(HttpClientRequest.appendUrl("/api/rpc")),
       }).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(RpcSerialization.layerJson)),
     ),
   )

--- a/src/services/shorten/client.ts
+++ b/src/services/shorten/client.ts
@@ -1,6 +1,8 @@
 import * as Context from "effect/Context"
 import * as Layer from "effect/Layer"
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
+import * as HttpClient from "effect/unstable/http/HttpClient"
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 import { RpcClientError } from "effect/unstable/rpc/RpcClientError"
 import * as RpcGroup from "effect/unstable/rpc/RpcGroup"
@@ -13,10 +15,10 @@ export class ShortenClient extends Context.Service<
 >()("app/ShortenClient") {
   static readonly layer = Layer.effect(ShortenClient, RpcClient.make(ShortenRpcs)).pipe(
     Layer.provide(
-      RpcClient.layerProtocolHttp({ url: "/api/rpc" }).pipe(
-        Layer.provide(FetchHttpClient.layer),
-        Layer.provide(RpcSerialization.layerJson),
-      ),
+      RpcClient.layerProtocolHttp({
+        url: "/api/rpc",
+        transformClient: HttpClient.mapRequest(HttpClientRequest.setUrl("/api/rpc")),
+      }).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(RpcSerialization.layerJson)),
     ),
   )
 }


### PR DESCRIPTION
## Summary
- normalize playground RPC requests to `/api/rpc`
- avoid the trailing slash that falls through to Vercel’s 404 route

## Verification
- `pnpm check`
- `pnpm exec oxlint src/services/shorten/client.ts`
- `pnpm exec oxfmt --check src/services/shorten/client.ts`