### PR TITLE
Fix playground file change detection

### DIFF
--- a/src/features/playground/services/monaco.ts
+++ b/src/features/playground/services/monaco.ts
@@ -156,7 +156,7 @@ export class Monaco extends Context.Service<Monaco>()("app/Monaco", {
           const disposable = editor.onDidChangeModelContent(() => {
             Queue.offerUnsafe(queue, editor.getValue())
           })
-          return Effect.sync(() => disposable.dispose())
+          return Effect.addFinalizer(() => Effect.sync(() => disposable.dispose()))
         })
 
         return {

--- a/src/features/playground/services/webcontainer.ts
+++ b/src/features/playground/services/webcontainer.ts
@@ -310,7 +310,7 @@ export class WebContainer extends Context.Service<WebContainer>()("app/WebContai
         const watcher = container.fs.watch(path, (_event) => {
           Queue.offerUnsafe(queue, void 0)
         })
-        return Effect.sync(() => watcher.close())
+        return Effect.addFinalizer(() => Effect.sync(() => watcher.close()))
       }).pipe(Stream.mapEffect(() => readFileString(path)))
       return Stream.fromEffect(readFileString(path)).pipe(
         Stream.concat(changes),


### PR DESCRIPTION
## Summary
- retain Monaco content listeners for the stream lifetime
- retain WebContainer file watchers for the stream lifetime
- restore playground recompilation and execution after editor changes

## Validation
- `pnpm check`
- `pnpm lint`
- Playwright smoke test confirming an editor update is persisted, detected by TypeScript watch mode, and executed