### PR TITLE
Fix playground terminal after watcher shutdown

### DIFF
--- a/src/features/playground/atoms/workspace.ts
+++ b/src/features/playground/atoms/workspace.ts
@@ -81,26 +81,48 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
             const spawned = yield* terminal.spawn({
               theme: get.once(terminalThemeAtom),
             })
-            spawned.terminal.open(el)
-            // jsh's line editor can stall when its PTY dimensions differ from xterm.
-            const process = yield* container.createShell(workspace.name, {
-              cols: spawned.terminal.cols,
-              rows: spawned.terminal.rows,
-            })
-            const writer = process.input.getWriter()
+            const shell = yield* container.createShell(workspace.name)
+            let process = shell.initial
+            let writer = process.input.getWriter()
+            let restarting: Promise<void> | undefined
+            const pipeOutput = (process: typeof shell.initial) => {
+              void process.output
+                .pipeTo(
+                  new WritableStream({
+                    write(data) {
+                      spawned.terminal.write(data)
+                    },
+                  }),
+                )
+                .catch(() => {})
+            }
             const mount = Effect.sync(() => {
-              process.output.pipeTo(
-                new WritableStream({
-                  write(data) {
-                    spawned.terminal.write(data)
-                  },
-                }),
-              )
-              spawned.terminal.onResize((terminal) => {
-                process.resize(terminal)
-              })
+              pipeOutput(process)
               spawned.terminal.onData((data) => {
-                writer.write(data)
+                if (data === "\x03") {
+                  // tsc-watch can leave jsh's input stuck after Ctrl+C, so replace the shell process.
+                  spawned.terminal.write("^C\r\n")
+                  if (restarting === undefined) {
+                    const restart = shell
+                      .restart()
+                      .then((next) => {
+                        process = next
+                        writer = process.input.getWriter()
+                        pipeOutput(process)
+                      })
+                      .catch((error) => {
+                        console.error("Unable to restart playground terminal", error)
+                      })
+                    restarting = restart
+                    void restart.then(() => {
+                      if (restarting === restart) restarting = undefined
+                    })
+                  }
+                } else if (restarting === undefined) {
+                  void writer.write(data)
+                } else {
+                  void restarting.then(() => writer.write(data))
+                }
               })
             })
             yield* mount
@@ -145,6 +167,7 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
               Stream.runForEach(() => spawned.resize),
               Effect.forkScoped,
             )
+            spawned.terminal.open(el)
             return spawned.terminal
           }, Effect.tapCause(Effect.logError)),
         )

--- a/src/features/playground/atoms/workspace.ts
+++ b/src/features/playground/atoms/workspace.ts
@@ -78,9 +78,14 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
         const terminalAtom = runtime.atom(
           Effect.fnUntraced(function* (get) {
             const el = yield* get.some(element)
-            const process = yield* container.createShell(workspace.name)
             const spawned = yield* terminal.spawn({
               theme: get.once(terminalThemeAtom),
+            })
+            spawned.terminal.open(el)
+            // jsh's line editor can stall when its PTY dimensions differ from xterm.
+            const process = yield* container.createShell(workspace.name, {
+              cols: spawned.terminal.cols,
+              rows: spawned.terminal.rows,
             })
             const writer = process.input.getWriter()
             const mount = Effect.sync(() => {
@@ -91,9 +96,11 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
                   },
                 }),
               )
+              spawned.terminal.onResize((terminal) => {
+                process.resize(terminal)
+              })
               spawned.terminal.onData((data) => {
-                // xterm emits DEL for Backspace, but WebContainer's jsh expects BS.
-                writer.write(data === "\x7f" ? "\x08" : data)
+                writer.write(data)
               })
             })
             yield* mount
@@ -138,7 +145,6 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
               Stream.runForEach(() => spawned.resize),
               Effect.forkScoped,
             )
-            spawned.terminal.open(el)
             return spawned.terminal
           }, Effect.tapCause(Effect.logError)),
         )

--- a/src/features/playground/atoms/workspace.ts
+++ b/src/features/playground/atoms/workspace.ts
@@ -92,7 +92,8 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
                 }),
               )
               spawned.terminal.onData((data) => {
-                writer.write(data)
+                // xterm emits DEL for Backspace, but WebContainer's jsh expects BS.
+                writer.write(data === "\x7f" ? "\x08" : data)
               })
             })
             yield* mount

--- a/src/features/playground/atoms/workspace.ts
+++ b/src/features/playground/atoms/workspace.ts
@@ -81,48 +81,29 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
             const spawned = yield* terminal.spawn({
               theme: get.once(terminalThemeAtom),
             })
-            const shell = yield* container.createShell(workspace.name)
-            let process = shell.initial
-            let writer = process.input.getWriter()
-            let restarting: Promise<void> | undefined
-            const pipeOutput = (process: typeof shell.initial) => {
-              void process.output
-                .pipeTo(
-                  new WritableStream({
-                    write(data) {
-                      spawned.terminal.write(data)
-                    },
-                  }),
-                )
-                .catch(() => {})
-            }
+            spawned.terminal.open(el)
+            const process = yield* container.createShell(workspace.name, {
+              cols: spawned.terminal.cols,
+              rows: spawned.terminal.rows,
+            })
+            const writer = process.input.getWriter()
             const mount = Effect.sync(() => {
-              pipeOutput(process)
+              process.output.pipeTo(
+                new WritableStream({
+                  write(data) {
+                    spawned.terminal.write(data)
+                  },
+                }),
+              )
+              spawned.terminal.onResize((dimensions) => {
+                process.resize(dimensions)
+              })
+              process.resize({
+                cols: spawned.terminal.cols,
+                rows: spawned.terminal.rows,
+              })
               spawned.terminal.onData((data) => {
-                if (data === "\x03") {
-                  // tsc-watch can leave jsh's input stuck after Ctrl+C, so replace the shell process.
-                  spawned.terminal.write("^C\r\n")
-                  if (restarting === undefined) {
-                    const restart = shell
-                      .restart()
-                      .then((next) => {
-                        process = next
-                        writer = process.input.getWriter()
-                        pipeOutput(process)
-                      })
-                      .catch((error) => {
-                        console.error("Unable to restart playground terminal", error)
-                      })
-                    restarting = restart
-                    void restart.then(() => {
-                      if (restarting === restart) restarting = undefined
-                    })
-                  }
-                } else if (restarting === undefined) {
-                  void writer.write(data)
-                } else {
-                  void restarting.then(() => writer.write(data))
-                }
+                writer.write(data)
               })
             })
             yield* mount
@@ -167,7 +148,6 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
               Stream.runForEach(() => spawned.resize),
               Effect.forkScoped,
             )
-            spawned.terminal.open(el)
             return spawned.terminal
           }, Effect.tapCause(Effect.logError)),
         )

--- a/src/features/playground/domain/workspace.ts
+++ b/src/features/playground/domain/workspace.ts
@@ -389,7 +389,6 @@ export const defaultWorkspace = Workspace.new({
     "@effect/platform-node": "latest",
     "@types/node": "latest",
     effect: "latest",
-    "tsc-watch": "latest",
     typescript: "6.0.2",
   },
   shells: [new WorkspaceShell({ command: "../run src/main.ts" })],

--- a/src/features/playground/services/terminal.ts
+++ b/src/features/playground/services/terminal.ts
@@ -24,9 +24,14 @@ export class Terminal extends Context.Service<
 >()("app/Terminal") {
   static readonly layer = Layer.succeed(this, {
     spawn: Effect.fnUntraced(function* (options) {
+      let resizeObserver: ResizeObserver | undefined
       const terminal = yield* Effect.acquireRelease(
         Effect.sync(() => new XTerm(options)),
-        (terminal) => Effect.sync(() => terminal.dispose()),
+        (terminal) =>
+          Effect.sync(() => {
+            resizeObserver?.disconnect()
+            terminal.dispose()
+          }),
       )
 
       const fitAddon = new FitAddon()
@@ -36,6 +41,8 @@ export class Terminal extends Context.Service<
       terminal.open = function (this: XTerm, parent: HTMLElement) {
         prevOpen.call(this, parent)
         fitAddon.fit()
+        resizeObserver = new ResizeObserver(() => fitAddon.fit())
+        resizeObserver.observe(parent)
       }
 
       return {

--- a/src/features/playground/services/webcontainer.ts
+++ b/src/features/playground/services/webcontainer.ts
@@ -44,7 +44,7 @@ export class WebContainer extends Context.Service<WebContainer>()("app/WebContai
      *
      * When the associated scope is closed, the process will be killed.
      */
-    function createShell(cwd: string) {
+    function createShell(cwd: string, terminal: { readonly cols: number; readonly rows: number }) {
       return Effect.acquireRelease(
         Effect.promise(() =>
           container.spawn("jsh", [], {
@@ -53,6 +53,7 @@ export class WebContainer extends Context.Service<WebContainer>()("app/WebContai
               PATH: WEBCONTAINER_BIN_PATH,
               NODE_NO_WARNINGS: "1",
             },
+            terminal,
           }),
         ),
         (process) => Effect.sync(() => process.kill()),

--- a/src/features/playground/services/webcontainer.ts
+++ b/src/features/playground/services/webcontainer.ts
@@ -593,6 +593,7 @@ const reportDiagnostic = (diagnostic) => {
   console.error(TypeScript.formatDiagnostic(diagnostic, formatHost))
 }
 const reportWatchStatus = (diagnostic) => {
+  if (diagnostic.code === 6031 || diagnostic.code === 6032) console.clear()
   console.info(TypeScript.formatDiagnostic(diagnostic, formatHost))
 }
 const host = TypeScript.createWatchCompilerHost(

--- a/src/features/playground/services/webcontainer.ts
+++ b/src/features/playground/services/webcontainer.ts
@@ -1,9 +1,5 @@
 import * as monaco from "@effect/monaco-editor/esm/vs/editor/editor.api"
-import {
-  WebContainer as WC,
-  type FileSystemTree,
-  type WebContainerProcess,
-} from "@webcontainer/api"
+import { WebContainer as WC, type FileSystemTree } from "@webcontainer/api"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
@@ -48,35 +44,19 @@ export class WebContainer extends Context.Service<WebContainer>()("app/WebContai
      *
      * When the associated scope is closed, the process will be killed.
      */
-    function createShell(cwd: string) {
-      const processes = new Set<WebContainerProcess>()
-      const spawn = async () => {
-        const process = await container.spawn("jsh", [], {
-          cwd,
-          env: {
-            PATH: WEBCONTAINER_BIN_PATH,
-            NODE_NO_WARNINGS: "1",
-          },
-        })
-        processes.add(process)
-        return process
-      }
+    function createShell(cwd: string, terminal: { readonly cols: number; readonly rows: number }) {
       return Effect.acquireRelease(
-        Effect.promise(async () => {
-          let active = await spawn()
-          return {
-            initial: active,
-            restart: async () => {
-              active.kill()
-              active = await spawn()
-              return active
+        Effect.promise(() =>
+          container.spawn("jsh", [], {
+            cwd,
+            env: {
+              PATH: WEBCONTAINER_BIN_PATH,
+              NODE_NO_WARNINGS: "1",
             },
-          } as const
-        }),
-        () =>
-          Effect.sync(() => {
-            processes.forEach((process) => process.kill())
+            terminal,
           }),
+        ),
+        (process) => Effect.sync(() => process.kill()),
       )
     }
 
@@ -602,19 +582,55 @@ Fs.writeFileSync(configPath, JSON.stringify({
   files: [program]
 }))
 
-function run() {
-  ChildProcess.spawn("tsc-watch", [
-    "-p", configPath,
-    "--onSuccess", \`node --enable-source-maps \${compiledProgram}\`
-  ], {
-    stdio: "inherit"
-  }).on("exit", function() {
-    console.clear()
-    run()
-  })
+// Keep the compiler and program under this process so Ctrl+C releases jsh's PTY.
+const TypeScript = require(Path.resolve("node_modules/typescript"))
+const formatHost = {
+  getCanonicalFileName: (path) => path,
+  getCurrentDirectory: TypeScript.sys.getCurrentDirectory,
+  getNewLine: () => TypeScript.sys.newLine
+}
+const reportDiagnostic = (diagnostic) => {
+  console.error(TypeScript.formatDiagnostic(diagnostic, formatHost))
+}
+const reportWatchStatus = (diagnostic) => {
+  console.info(TypeScript.formatDiagnostic(diagnostic, formatHost))
+}
+const host = TypeScript.createWatchCompilerHost(
+  configPath,
+  {},
+  TypeScript.sys,
+  TypeScript.createSemanticDiagnosticsBuilderProgram,
+  reportDiagnostic,
+  reportWatchStatus
+)
+const afterProgramCreate = host.afterProgramCreate
+let running
+
+host.afterProgramCreate = (builder) => {
+  afterProgramCreate?.(builder)
+  running?.kill("SIGKILL")
+  running = undefined
+  const diagnostics = TypeScript.getPreEmitDiagnostics(builder.getProgram())
+  if (diagnostics.length === 0) {
+    running = ChildProcess.spawn(process.execPath, [
+      "--enable-source-maps",
+      compiledProgram
+    ], {
+      stdio: "inherit"
+    })
+  }
 }
 
-run()
+const watcher = TypeScript.createWatchProgram(host)
+
+function stop(exitCode) {
+  running?.kill("SIGKILL")
+  watcher.close()
+  process.exit(exitCode)
+}
+
+process.once("SIGINT", () => stop(130))
+process.once("SIGTERM", () => stop(143))
 `
 
 const devToolsProxyExe = `#!/usr/bin/env node

--- a/src/features/playground/services/webcontainer.ts
+++ b/src/features/playground/services/webcontainer.ts
@@ -1,5 +1,9 @@
 import * as monaco from "@effect/monaco-editor/esm/vs/editor/editor.api"
-import { WebContainer as WC, type FileSystemTree } from "@webcontainer/api"
+import {
+  WebContainer as WC,
+  type FileSystemTree,
+  type WebContainerProcess,
+} from "@webcontainer/api"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
@@ -44,19 +48,35 @@ export class WebContainer extends Context.Service<WebContainer>()("app/WebContai
      *
      * When the associated scope is closed, the process will be killed.
      */
-    function createShell(cwd: string, terminal: { readonly cols: number; readonly rows: number }) {
+    function createShell(cwd: string) {
+      const processes = new Set<WebContainerProcess>()
+      const spawn = async () => {
+        const process = await container.spawn("jsh", [], {
+          cwd,
+          env: {
+            PATH: WEBCONTAINER_BIN_PATH,
+            NODE_NO_WARNINGS: "1",
+          },
+        })
+        processes.add(process)
+        return process
+      }
       return Effect.acquireRelease(
-        Effect.promise(() =>
-          container.spawn("jsh", [], {
-            cwd,
-            env: {
-              PATH: WEBCONTAINER_BIN_PATH,
-              NODE_NO_WARNINGS: "1",
+        Effect.promise(async () => {
+          let active = await spawn()
+          return {
+            initial: active,
+            restart: async () => {
+              active.kill()
+              active = await spawn()
+              return active
             },
-            terminal,
+          } as const
+        }),
+        () =>
+          Effect.sync(() => {
+            processes.forEach((process) => process.kill())
           }),
-        ),
-        (process) => Effect.sync(() => process.kill()),
       )
     }
 


### PR DESCRIPTION
## Summary
- replace the nested `tsc-watch` process with TypeScript’s in-process watch API
- explicitly stop the running program and compiler watch on Ctrl+C so `jsh` regains its PTY
- initialize and synchronize WebContainer PTY dimensions with xterm
- observe terminal layout changes so wrapped input remains correctly rendered
- clear dependency-install output when initial or incremental compilation starts
- remove the now-unused `tsc-watch` playground dependency

## Verification
- `pnpm check`
- `pnpm lint`
- formatting and `git diff --check`
- Playwright: interrupt the watcher, wait 10 seconds, type and edit a 130-character two-sentence command at 50 ms per key, and verify rendered input and exact output
- Playwright: exercise a long Ctrl+R search, cancel it, and verify the next command executes
- Playwright: verify dependency output is cleared while watcher status remains visible

Closes #1400