### PR TITLE
Improve playground terminal output

### DIFF
--- a/src/features/playground/components/terminal.css
+++ b/src/features/playground/components/terminal.css
@@ -1,4 +1,11 @@
+.xterm {
+  padding: 0.5rem;
+}
+
 .xterm-scrollable-element {
   overflow-y: auto;
-  padding: 0.5rem;
+}
+
+.xterm .xterm-viewport {
+  background-color: transparent;
 }

--- a/src/features/playground/services/webcontainer.ts
+++ b/src/features/playground/services/webcontainer.ts
@@ -574,6 +574,7 @@ Fs.writeFileSync(configPath, JSON.stringify({
       target: "esnext"
     }),
     outDir,
+    preserveWatchOutput: false,
     rootDir: Path.dirname(program),
     skipLibCheck: true,
     sourceMap: true,
@@ -584,18 +585,8 @@ Fs.writeFileSync(configPath, JSON.stringify({
 
 // Keep the compiler and program under this process so Ctrl+C releases jsh's PTY.
 const TypeScript = require(Path.resolve("node_modules/typescript"))
-const formatHost = {
-  getCanonicalFileName: (path) => path,
-  getCurrentDirectory: TypeScript.sys.getCurrentDirectory,
-  getNewLine: () => TypeScript.sys.newLine
-}
-const reportDiagnostic = (diagnostic) => {
-  console.error(TypeScript.formatDiagnostic(diagnostic, formatHost))
-}
-const reportWatchStatus = (diagnostic) => {
-  if (diagnostic.code === 6031 || diagnostic.code === 6032) console.clear()
-  console.info(TypeScript.formatDiagnostic(diagnostic, formatHost))
-}
+const reportDiagnostic = TypeScript.createDiagnosticReporter(TypeScript.sys, true)
+const reportWatchStatus = TypeScript.createWatchStatusReporter(TypeScript.sys, true)
 const host = TypeScript.createWatchCompilerHost(
   configPath,
   {},


### PR DESCRIPTION
## Summary
- move terminal padding to the xterm element so FitAddon accounts for it
- make the xterm viewport transparent so terminal theme backgrounds remain seamless
- use TypeScript’s pretty CLI diagnostic and watch-status reporters
- clear prior output on watch compilation with `preserveWatchOutput: false`

## Verification
- `pnpm check`
- `pnpm lint`
- formatting and `git diff --check`
- verified the terminal viewport remains contained on desktop and mobile
- verified matching terminal backgrounds in light and dark themes
- verified timestamped pretty watch output and colorized source-context errors
- verified the terminal remains interactive after Ctrl+C
