### PR TITLE
Preserve playground terminal on reset

### DIFF
--- a/src/features/playground/atoms/import.ts
+++ b/src/features/playground/atoms/import.ts
@@ -51,10 +51,13 @@ export const autoSaveAtom = Atom.family((handle: AtomWorkspaceHandle) =>
 )
 
 export const resetAtom = Atom.fnSync((handle: AtomWorkspaceHandle, get) => {
-  window.location.hash = ""
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `${window.location.pathname}${window.location.search}`,
+  )
   get.set(autoSaveWorkspaceAtom, Option.none())
   get.set(handle.resetContent, undefined)
-  get.refresh(importAtom)
 })
 
 const autoSaveWorkspaceAtom = Atom.kvs({

--- a/src/features/playground/atoms/workspace.ts
+++ b/src/features/playground/atoms/workspace.ts
@@ -162,14 +162,23 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
 
       const resetContent = Atom.fn<void>()(
         Effect.fnUntraced(function* (_, get) {
-          const files = Array.filterMap([...defaultWorkspace.filePaths], ([file, path]) =>
+          const currentWorkspace = get(handle.workspace)
+          const resetWorkspace = new Workspace({
+            name: currentWorkspace.name,
+            tree: defaultWorkspace.tree,
+            initialFilePath: defaultWorkspace.initialFilePath,
+            prepare: defaultWorkspace.prepare,
+            shells: currentWorkspace.shells,
+            snapshots: defaultWorkspace.snapshots,
+          })
+          const files = Array.filterMap([...resetWorkspace.filePaths], ([file, path]) =>
             file._tag === "File" ? Result.succeed(Tuple.make(file, path)) : Result.failVoid,
           )
           yield* Effect.forEach(
             files,
             ([file, path]) =>
               Effect.gen(function* () {
-                const fullPath = defaultWorkspace.relativePath(path)
+                const fullPath = resetWorkspace.relativePath(path)
                 const parts = fullPath.split("/")
                 if (parts.length > 1) {
                   const parentDir = parts.slice(0, -1).join("/")
@@ -183,8 +192,8 @@ export const workspaceHandleAtom = Atom.family((workspace: Workspace) =>
               }).pipe(Effect.ignore),
             { concurrency: "unbounded", discard: true },
           )
-          get.set(handle.workspace, defaultWorkspace)
-          get.set(selectedFile, defaultWorkspace.initialFile)
+          get.set(handle.workspace, resetWorkspace)
+          get.set(selectedFile, resetWorkspace.initialFile)
         }),
       )
 

--- a/src/features/playground/components/terminal.tsx
+++ b/src/features/playground/components/terminal.tsx
@@ -1,5 +1,4 @@
 import { useAtomSet, useAtomMount } from "@effect/atom-react"
-import { constVoid } from "effect/Function"
 import * as Option from "effect/Option"
 import { useCallback, useMemo } from "react"
 import { useWorkspaceHandle } from "../context/workspace"
@@ -20,10 +19,10 @@ export function Terminal({ shell }: { readonly shell: WorkspaceShell }) {
 
 function Shell({ shell }: { readonly shell: WorkspaceShell }) {
   const handle = useWorkspaceHandle()
-  const { element, terminal } = handle.createTerminal(
-    new WorkspaceTerminal({ command: shell.command }),
+  const { element, terminal } = useMemo(
+    () => handle.createTerminal(new WorkspaceTerminal({ command: shell.command })),
+    [handle, shell.command],
   )
-  useMemo(constVoid, [terminal])
   useAtomMount(terminal)
 
   const setElement = useAtomSet(element)


### PR DESCRIPTION
## Summary
- reset playground state in place instead of refreshing the imported workspace
- clear shared URLs without emitting a hashchange
- write default files under the active workspace directory
- preserve active shell configuration during reset
- keep terminal atom identity stable when workspace content changes

## Verification
- `pnpm check`
- `pnpm lint`
- formatting and `git diff --check`
- reset a shared playground after the watcher is ready
- verified the exact xterm DOM node survives reset
- verified the URL hash is cleared and the terminal remains interactive
