### PR TITLE
fix: make native scrollbars follow the active color scheme

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -178,6 +178,10 @@
 }
 
 :root {
+  /* Native UI (scrollbars, form controls) must follow the active theme, which the
+     inline script in BaseLayout resolves to a `dark` class on <html> (auto included) */
+  color-scheme: light;
+
   --zinc-700: #3f3f46;
   --zinc-800: #27272a;
   --zinc-950: #09090b;
@@ -190,6 +194,8 @@
 }
 
 .dark {
+  color-scheme: dark;
+
   --background: oklch(0.141 0.004 285.766);
   --foreground: oklch(0.985 0 0);
   --muted-foreground: oklch(0.712 0.013 285.965);


### PR DESCRIPTION
## Problem

The site never declares `color-scheme`, so browsers always paint their default **light** UI for native scroll containers — the docs sidebar, the "On this page" rail, and the window scrollbar all show a white scrollbar in dark mode.

## Fix

Declare `color-scheme: light` on `:root` and `color-scheme: dark` on `.dark` in `src/styles/global.css`. The inline script in `BaseLayout.astro` already resolves the light/dark/**auto** theme selector to the `dark` class on `<html>` before first paint (including system-preference changes), so all three selector modes are covered with no new JavaScript. The property inherits, so every current and future `overflow` container gets the right scrollbar for free.

## Before / After — docs sidebar, dark theme

| Before | After |
| --- | --- |
| ![white scrollbar on dark sidebar](https://raw.githubusercontent.com/Effect-TS/website/assets/scrollbar-color-scheme-screenshots/before-dark-sidebar.png) | ![dark scrollbar on dark sidebar](https://raw.githubusercontent.com/Effect-TS/website/assets/scrollbar-color-scheme-screenshots/after-dark-sidebar.png) |

## Light theme (no regression)

Before/after screenshots in light theme are byte-identical:

| Before | After |
| --- | --- |
| ![light sidebar before](https://raw.githubusercontent.com/Effect-TS/website/assets/scrollbar-color-scheme-screenshots/before-light-sidebar.png) | ![light sidebar after](https://raw.githubusercontent.com/Effect-TS/website/assets/scrollbar-color-scheme-screenshots/after-light-sidebar.png) |

## Full page, dark theme, after

![full docs page with dark window and sidebar scrollbars](https://raw.githubusercontent.com/Effect-TS/website/assets/scrollbar-color-scheme-screenshots/after-dark-full.png)

## Verification

Drove headless Chromium against `/docs/v3/getting-started/introduction` for each theme-selector mode and read the computed style on `<html>`:

| Selector mode | Resolved theme | Computed `color-scheme` |
| --- | --- | --- |
| Dark | dark | `dark` |
| Light | light | `light` |
| Auto (system dark) | dark | `dark` |

(Before the fix the computed value was `normal` in all modes.)

Screenshots live on the non-merge branch `assets/scrollbar-color-scheme-screenshots`, which can be deleted once this PR is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)