### PR TITLE
fix: replace broken apply job link

### DIFF
--- a/src/pages/effect-jobs.astro
+++ b/src/pages/effect-jobs.astro
@@ -61,7 +61,7 @@ function linkDisplay(url: string): string {
       </p>
       <div class="mt-8 flex flex-wrap items-center gap-3">
         <a
-          href="https://github.com/effect-ts/website-v2/issues/new?template=post-a-job.yml"
+          href="https://github.com/effect-ts/website/issues/new?template=post-a-job.yml"
           target="_blank"
           rel="noopener noreferrer"
           class="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-base font-medium text-zinc-900 transition-all hover:bg-zinc-100 hover:shadow-[0_0_20px_rgba(255,255,255,0.15)]"
@@ -155,7 +155,7 @@ function linkDisplay(url: string): string {
           {/* CTA card */}
           <li class={`bg-zinc-950 ${ctaSpan}`}>
             <a
-              href="https://github.com/effect-ts/website-v2/issues/new?template=post-a-job.yml"
+              href="https://github.com/effect-ts/website/issues/new?template=post-a-job.yml"
               target="_blank"
               rel="noopener noreferrer"
               class="group flex h-full flex-col p-6 transition-colors hover:bg-zinc-900/80 focus-visible:bg-zinc-900/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white"


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

**Problem:** The "Post a job" CTA on the jobs page (https://effect.website/effect-jobs) links to the old effect-ts/website-v2 repo, which no longer exists. Clicking "Post a job" results in a 404 error.

**Fix:** Pointed both "Post a job" links to the current effect-ts/website repo issue template:
- https://github.com/effect-ts/website-v2/issues/new?template=post-a-job.yml
- → https://github.com/effect-ts/website/issues/new?template=post-a-job.yml

## Related

- Related Issue #
- Closes #
