### PR TITLE
Add API reference Open Graph images

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       "./src/assets/fonts/Inter-Regular.ttf",
       "./src/assets/fonts/Inter-Bold.ttf",
       "./src/assets/fonts/JetBrainsMono-Regular.ttf",
+      "./src/assets/fonts/JetBrainsMono-Bold.ttf",
       ...ogAssetPngs,
     ],
   }),

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check": "astro sync && tsc -b tsconfig.json",
     "mixedbread:index": "node scripts/mixedbread/index.ts",
     "api-reference:generate": "pnpm --dir scripts/api-reference generate",
-    "test": "node --test scripts/api-reference/snapshot.test.mjs scripts/mixedbread/blog.test.ts scripts/mixedbread/documentation.test.ts src/features/api-reference/CodeSnippet.test.ts src/services/search/analytics.test.ts src/services/search/domain.test.ts",
+    "test": "node --test scripts/api-reference/snapshot.test.mjs scripts/mixedbread/blog.test.ts scripts/mixedbread/documentation.test.ts src/features/api-reference/CodeSnippet.test.ts src/features/api-reference/open-graph.test.ts src/services/search/analytics.test.ts src/services/search/domain.test.ts",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "fmt": "oxfmt --check && prettier --check \"**/*.astro\"",

--- a/src/features/api-reference/open-graph.test.ts
+++ b/src/features/api-reference/open-graph.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { loadAssets, renderApiReferenceOg } from "../../services/OpenGraph.ts"
+import { type ApiReferenceOpenGraphEntry, resolveApiReferenceOpenGraph } from "./open-graph.ts"
+
+const entries = [
+  {
+    version: "v4",
+    revision: "revision-v4",
+    packageName: "effect",
+    packageSlug: "effect",
+    packageDescription: "The Effect core package.",
+    modulePath: "Effect",
+  },
+  {
+    version: "v4",
+    revision: "revision-v4",
+    packageName: "effect",
+    packageSlug: "effect",
+    packageDescription: "The Effect core package.",
+    modulePath: "unstable/http/HttpClient",
+  },
+  {
+    version: "v3",
+    revision: "revision-v3",
+    packageName: "@effect/platform-node",
+    packageSlug: "platform-node",
+    packageDescription: "Node.js integrations for Effect.",
+    modulePath: "NodeHttpClient",
+  },
+] satisfies ReadonlyArray<ApiReferenceOpenGraphEntry>
+
+test("resolves a version index", () => {
+  assert.deepEqual(resolveApiReferenceOpenGraph("docs/v4/api", entries), {
+    description: "Browse the Effect v4 API reference by package and module.",
+    revision: "revision-v4",
+    template: {
+      eyebrow: "Effect Docs",
+      title: "API Reference",
+    },
+  })
+})
+
+test("resolves a scoped package index", () => {
+  assert.deepEqual(resolveApiReferenceOpenGraph("docs/v3/api/platform-node", entries), {
+    description: "Node.js integrations for Effect.",
+    revision: "revision-v3",
+    template: {
+      eyebrow: "API Reference",
+      title: "@effect/platform-node",
+    },
+  })
+})
+
+test("resolves a nested module", () => {
+  assert.deepEqual(
+    resolveApiReferenceOpenGraph("docs/v4/api/effect/unstable/http/HttpClient", entries),
+    {
+      description: "Unstable HttpClient API reference for effect.",
+      revision: "revision-v4",
+      template: {
+        eyebrow: "API Reference",
+        title: "HttpClient",
+      },
+    },
+  )
+})
+
+test("rejects unknown or malformed routes", () => {
+  assert.equal(resolveApiReferenceOpenGraph("docs/v5/api", entries), undefined)
+  assert.equal(resolveApiReferenceOpenGraph("docs/v4/api/unknown", entries), undefined)
+  assert.equal(resolveApiReferenceOpenGraph("docs/v4/api/effect/unknown", entries), undefined)
+  assert.equal(resolveApiReferenceOpenGraph("docs/v4/getting-started", entries), undefined)
+})
+
+test("renders a 1200 by 630 PNG", async () => {
+  const image = await renderApiReferenceOg(
+    {
+      eyebrow: "API Reference",
+      title: "HttpClient",
+    },
+    await loadAssets(),
+  )
+  const view = new DataView(image.buffer, image.byteOffset, image.byteLength)
+
+  assert.deepEqual(image.slice(0, 8), Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]))
+  assert.equal(view.getUint32(16), 1200)
+  assert.equal(view.getUint32(20), 630)
+})

--- a/src/features/api-reference/open-graph.ts
+++ b/src/features/api-reference/open-graph.ts
@@ -1,0 +1,71 @@
+import type { ApiReferenceOgTemplateProps } from "@/services/OpenGraph"
+
+export interface ApiReferenceOpenGraphEntry {
+  readonly modulePath: string
+  readonly packageDescription: string
+  readonly packageName: string
+  readonly packageSlug: string
+  readonly revision: string
+  readonly version: string
+}
+
+export interface ApiReferenceOpenGraphCard {
+  readonly description: string
+  readonly revision: string
+  readonly template: ApiReferenceOgTemplateProps
+}
+
+export function resolveApiReferenceOpenGraph(
+  documentPath: string,
+  entries: ReadonlyArray<ApiReferenceOpenGraphEntry>,
+): ApiReferenceOpenGraphCard | undefined {
+  const [docs, version, api, packageSlug, ...moduleSegments] = documentPath.split("/")
+  if (docs !== "docs" || version === undefined || api !== "api") return undefined
+
+  const versionEntries = entries.filter((entry) => entry.version === version)
+  const firstVersionEntry = versionEntries[0]
+  if (firstVersionEntry === undefined) return undefined
+
+  if (packageSlug === undefined) {
+    return {
+      description: `Browse the Effect ${version} API reference by package and module.`,
+      revision: firstVersionEntry.revision,
+      template: {
+        eyebrow: "Effect Docs",
+        title: "API Reference",
+      },
+    }
+  }
+
+  const packageEntries = versionEntries.filter((entry) => entry.packageSlug === packageSlug)
+  const firstPackageEntry = packageEntries[0]
+  if (firstPackageEntry === undefined) return undefined
+
+  if (moduleSegments.length === 0) {
+    return {
+      description: firstPackageEntry.packageDescription,
+      revision: firstPackageEntry.revision,
+      template: {
+        eyebrow: "API Reference",
+        title: firstPackageEntry.packageName,
+      },
+    }
+  }
+
+  const modulePath = moduleSegments.join("/")
+  const moduleEntry = packageEntries.find((entry) => entry.modulePath === modulePath)
+  if (moduleEntry === undefined) return undefined
+  const moduleName = moduleEntry.modulePath.split("/").at(-1) ?? moduleEntry.modulePath
+  const isUnstable =
+    moduleEntry.packageName === "effect" && moduleEntry.modulePath.startsWith("unstable/")
+  const description = `${isUnstable ? "Unstable " : ""}${moduleName} API reference for ${moduleEntry.packageName}.`
+
+  return {
+    description,
+    revision: moduleEntry.revision,
+    template: {
+      eyebrow: "API Reference",
+      title: moduleName,
+    },
+  }
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,9 +12,15 @@ interface Props {
   readonly title?: string | undefined
   readonly description?: string | undefined
   readonly forceDark?: boolean | undefined
+  readonly ogImageVersion?: string | undefined
 }
 
-const { title = "Effect | Production Grade TypeScript", description, forceDark = false } = Astro.props
+const {
+  title = "Effect | Production Grade TypeScript",
+  description,
+  forceDark = false,
+  ogImageVersion,
+} = Astro.props
 
 const getOgImagePath = () => {
   const pathname = Astro.url.pathname
@@ -25,6 +31,7 @@ const getOgImagePath = () => {
 
 const ogImagePath = getOgImagePath()
 const ogImageUrl = new URL(ogImagePath, Astro.url.origin)
+if (ogImageVersion !== undefined) ogImageUrl.searchParams.set("v", ogImageVersion)
 
 const pagePathname = Astro.url.pathname.replace(/\/$/, "")
 const canonicalUrl = new URL(pagePathname, Astro.site)

--- a/src/pages/docs/[version]/api/[package]/[...module].astro
+++ b/src/pages/docs/[version]/api/[package]/[...module].astro
@@ -8,6 +8,7 @@ import Navigation from "@/components/navigation/Navigation.astro"
 import ApiDeclaration from "@/features/api-reference/ApiDeclaration.astro"
 import ApiMobileNavigation from "@/features/api-reference/ApiMobileNavigation.astro"
 import * as ApiReference from "@/features/api-reference/ApiReference"
+import { resolveApiReferenceOpenGraph } from "@/features/api-reference/open-graph"
 import BaseLayout from "@/layouts/BaseLayout.astro"
 import { PAGE_TITLE_ID } from "@/lib/constants/skip-link"
 
@@ -29,6 +30,10 @@ const reflection = await ApiReference.loadReflection(entry.data)
 const apiModule = await ApiReference.ApiReference.moduleView(reflection)
 const moduleName = entry.data.modulePath.split("/").at(-1) ?? entry.data.modulePath
 const displayName = entry.data.packageName.replace("@effect/", "")
+const openGraph = resolveApiReferenceOpenGraph(
+  `docs/${entry.data.version}/api/${entry.data.packageSlug}/${entry.data.modulePath}`,
+  [entry.data],
+)
 const packageEntries = allEntries
   .filter(
     (candidate) =>
@@ -114,7 +119,11 @@ function sidebarModuleName(modulePath: string, group: string): string {
 }
 ---
 
-<BaseLayout title={`${moduleName} API Reference | Effect`}>
+<BaseLayout
+  title={`${moduleName} API Reference | Effect`}
+  description={openGraph?.description}
+  ogImageVersion={entry.data.revision}
+>
   <Navigation activeSlug="api" wide />
 
   <div class="relative w-full pt-16">

--- a/src/pages/docs/[version]/api/[package]/index.astro
+++ b/src/pages/docs/[version]/api/[package]/index.astro
@@ -6,6 +6,7 @@ import { ChevronDown, Search } from "@lucide/astro"
 import Footer from "@/components/Footer.astro"
 import Navigation from "@/components/navigation/Navigation.astro"
 import ApiMobileNavigation from "@/features/api-reference/ApiMobileNavigation.astro"
+import { resolveApiReferenceOpenGraph } from "@/features/api-reference/open-graph"
 import { PAGE_TITLE_ID } from "@/lib/constants/skip-link"
 import BaseLayout from "@/layouts/BaseLayout.astro"
 
@@ -67,6 +68,10 @@ const collection = await getCollection("apiReference")
 const { modules, pkg, version } = Astro.props
 
 const displayName = pkg.name.replace("@effect/", "")
+const openGraph = resolveApiReferenceOpenGraph(
+  `docs/${version}/api/${pkg.slug}`,
+  modules.map((module) => module.data),
+)
 
 const availableVersions = new Set(
   collection
@@ -139,7 +144,11 @@ function moduleName(modulePath: string, group: string): string {
 }
 ---
 
-<BaseLayout title="API Reference">
+<BaseLayout
+  title={`${pkg.name} API Reference | Effect`}
+  description={pkg.description}
+  ogImageVersion={openGraph?.revision}
+>
   <Navigation activeSlug="api" wide />
 
   <div class="relative w-full pt-16">

--- a/src/pages/docs/[version]/api/index.astro
+++ b/src/pages/docs/[version]/api/index.astro
@@ -6,6 +6,7 @@ import { ChevronDown, Search } from "@lucide/astro"
 import Footer from "@/components/Footer.astro"
 import Navigation from "@/components/navigation/Navigation.astro"
 import ApiMobileNavigation from "@/features/api-reference/ApiMobileNavigation.astro"
+import { resolveApiReferenceOpenGraph } from "@/features/api-reference/open-graph"
 import { PAGE_TITLE_ID } from "@/lib/constants/skip-link"
 import BaseLayout from "@/layouts/BaseLayout.astro"
 
@@ -29,6 +30,10 @@ export const getStaticPaths = (async () => {
 }) satisfies GetStaticPaths
 
 const { entries, version } = Astro.props
+const openGraph = resolveApiReferenceOpenGraph(
+  `docs/${version}/api`,
+  entries.map((entry) => entry.data),
+)
 
 const groupNames: Record<string, Record<string, string>> = {
   v3: {
@@ -177,7 +182,11 @@ const mobilePackages = [
 ]
 ---
 
-<BaseLayout title="API Reference">
+<BaseLayout
+  title={`Effect ${version} API Reference`}
+  description={openGraph?.description}
+  ogImageVersion={openGraph?.revision}
+>
   <Navigation activeSlug="api" wide />
 
   <div class="relative w-full pt-16">

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -6,7 +6,8 @@ import * as Function from "effect/Function"
 import * as Option from "effect/Option"
 import { readFile } from "node:fs/promises"
 import type { OgTemplateProps } from "@/services/OpenGraph"
-import { loadAssets, renderBlogOg, renderDocsOg } from "@/services/OpenGraph"
+import { resolveApiReferenceOpenGraph } from "@/features/api-reference/open-graph"
+import { loadAssets, renderApiReferenceOg, renderBlogOg, renderDocsOg } from "@/services/OpenGraph"
 
 // On-demand server endpoint: slugs derive from arbitrary page pathnames
 // (see BaseLayout.getOgImagePath), so the route cannot be enumerated at build
@@ -104,6 +105,19 @@ export const GET: APIRoute = async (context) => {
   const staticImage = await readStaticPng(maybeSlug.value)
   if (Option.isSome(staticImage)) {
     return pngResponse(staticImage.value)
+  }
+
+  if (/^docs\/v\d+\/api(?:\/|$)/.test(maybeSlug.value)) {
+    const entries = await getCollection("apiReference")
+    const card = resolveApiReferenceOpenGraph(
+      maybeSlug.value,
+      entries.map((entry) => entry.data),
+    )
+    if (card === undefined) {
+      return notFound()
+    }
+    const ogAssets = await loadAssets()
+    return pngResponse(await renderApiReferenceOg(card.template, ogAssets))
   }
 
   if (maybeSlug.value.startsWith("docs/")) {

--- a/src/services/OpenGraph.ts
+++ b/src/services/OpenGraph.ts
@@ -2,11 +2,16 @@ import type { CSSProperties } from "react"
 import { Resvg } from "@resvg/resvg-js"
 import { readFile } from "node:fs/promises"
 import satori, { type SatoriOptions } from "satori"
-import { OPENGRAPH_IMAGE_HEIGHT, OPENGRAPH_IMAGE_WIDTH } from "@/lib/open-graph"
+import { OPENGRAPH_IMAGE_HEIGHT, OPENGRAPH_IMAGE_WIDTH } from "../lib/open-graph.ts"
 
 export interface OgTemplateProps {
   readonly title: string
   readonly subtitle?: string | undefined
+}
+
+export interface ApiReferenceOgTemplateProps {
+  readonly eyebrow: string
+  readonly title: string
 }
 
 type SatoriFont = NonNullable<SatoriOptions["fonts"]>[number]
@@ -29,13 +34,15 @@ export async function loadAssets(): Promise<OgAssets> {
   if (_assets !== null) {
     return _assets
   }
-  const [interRegular, interBold, jetbrainsMono, docsBase, blogBase] = await Promise.all([
-    readFile("src/assets/fonts/Inter-Regular.ttf"),
-    readFile("src/assets/fonts/Inter-Bold.ttf"),
-    readFile("src/assets/fonts/JetBrainsMono-Regular.ttf"),
-    readFile("src/pages/og/_assets/docs/base.png"),
-    readFile("src/pages/og/_assets/blog/base.png"),
-  ])
+  const [interRegular, interBold, jetbrainsMono, jetbrainsMonoBold, docsBase, blogBase] =
+    await Promise.all([
+      readFile("src/assets/fonts/Inter-Regular.ttf"),
+      readFile("src/assets/fonts/Inter-Bold.ttf"),
+      readFile("src/assets/fonts/JetBrainsMono-Regular.ttf"),
+      readFile("src/assets/fonts/JetBrainsMono-Bold.ttf"),
+      readFile("src/pages/og/_assets/docs/base.png"),
+      readFile("src/pages/og/_assets/blog/base.png"),
+    ])
   const fonts: Array<SatoriFont> = [
     {
       name: "Inter",
@@ -54,6 +61,12 @@ export async function loadAssets(): Promise<OgAssets> {
       style: "normal",
       data: toArrayBuffer(jetbrainsMono),
       weight: 400,
+    },
+    {
+      name: "JetBrains Mono",
+      style: "normal",
+      data: toArrayBuffer(jetbrainsMonoBold),
+      weight: 700,
     },
   ]
   _assets = {
@@ -79,6 +92,25 @@ export async function renderDocsOg(props: OgTemplateProps, assets: OgAssets): Pr
     height: OPENGRAPH_IMAGE_HEIGHT,
     fonts: assets.fonts as SatoriOptions["fonts"],
   })
+  return renderPng(svg)
+}
+
+export async function renderApiReferenceOg(
+  props: ApiReferenceOgTemplateProps,
+  assets: OgAssets,
+): Promise<Uint8Array> {
+  const svg = await satori(
+    createApiReferenceTemplate({
+      bgDataUri: assets.docsBgDataUri,
+      eyebrow: safeText(props.eyebrow),
+      title: safeText(props.title),
+    }),
+    {
+      width: OPENGRAPH_IMAGE_WIDTH,
+      height: OPENGRAPH_IMAGE_HEIGHT,
+      fonts: assets.fonts as SatoriOptions["fonts"],
+    },
+  )
   return renderPng(svg)
 }
 
@@ -365,6 +397,91 @@ const createDocsTemplate = (props: OgTemplateProps, docsBgDataUri: string): OgNo
     title: props.title,
     subtitle: props.subtitle,
     bgDataUri: docsBgDataUri,
+  })
+}
+
+const createApiReferenceTemplate = ({
+  eyebrow,
+  title,
+  bgDataUri,
+}: ApiReferenceOgTemplateProps & { readonly bgDataUri: string }): OgNode => {
+  return createNode("div", {
+    style: {
+      width: "1200px",
+      height: "630px",
+      display: "flex",
+      position: "relative",
+      fontFamily: "JetBrains Mono",
+    },
+    children: [
+      createNode("img", {
+        src: bgDataUri,
+        width: OPENGRAPH_IMAGE_WIDTH,
+        height: OPENGRAPH_IMAGE_HEIGHT,
+      }),
+      createNode("div", {
+        style: {
+          position: "absolute",
+          top: "320px",
+          left: "80px",
+          right: "80px",
+          display: "flex",
+          flexDirection: "column",
+        },
+        children: [
+          createNode("div", {
+            style: {
+              display: "flex",
+              alignItems: "center",
+            },
+            children: [
+              createNode("div", {
+                style: {
+                  color: "#a1a1aa",
+                  display: "flex",
+                  fontSize: "22px",
+                  fontWeight: 500,
+                  letterSpacing: "0.04em",
+                  lineHeight: 1.1,
+                  textTransform: "uppercase",
+                },
+                children: eyebrow,
+              }),
+            ],
+          }),
+          createNode("div", {
+            style: {
+              color: "#ffffff",
+              display: "flex",
+              fontSize: "64px",
+              fontWeight: 600,
+              letterSpacing: "-0.02em",
+              lineHeight: 1.1,
+              marginTop: "30px",
+              maxWidth: "1040px",
+            },
+            children: title,
+          }),
+        ],
+      }),
+      createNode("div", {
+        style: {
+          position: "absolute",
+          right: "80px",
+          bottom: "20px",
+          paddingLeft: "12px",
+          backgroundColor: "#08090b",
+          color: "#a1a1aa",
+          display: "flex",
+          fontSize: "22px",
+          fontWeight: 500,
+          letterSpacing: "0.04em",
+          lineHeight: 1.1,
+          textTransform: "uppercase",
+        },
+        children: "API Reference",
+      }),
+    ],
   })
 }
 


### PR DESCRIPTION
## Summary
- add API-aware Open Graph resolution for version, package, and module routes
- render API reference cards with revisioned image URLs and unstable module metadata
- improve API page titles and descriptions

## Verification
- `pnpm test`
- `pnpm check`
- `pnpm lint`
- `pnpm fmt`
- `pnpm build`