### PR TITLE
Use Expressive Code for API reference

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,8 +1,6 @@
 import mdx from "@astrojs/mdx"
 import react from "@astrojs/react"
 import vercel from "@astrojs/vercel"
-import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-sections"
-import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers"
 import tailwindcss from "@tailwindcss/vite"
 import expressiveCode from "astro-expressive-code"
 import { defineConfig, envField, fontProviders, svgoOptimizer } from "astro/config"
@@ -12,7 +10,6 @@ import svgr from "vite-plugin-svgr"
 import { monacoEditorPlugin } from "./src/features/playground/plugins/monaco-editor"
 import { docsLegacyRedirectList } from "./src/generated/docs-legacy-redirects"
 import { twieRedirectList } from "./src/generated/twie-redirects"
-import { pluginOpenInPlayground } from "./src/plugins/expressive-code/open-in-playground.ts"
 
 const GoogleFontProvider = fontProviders.google()
 
@@ -89,16 +86,7 @@ export default defineConfig({
     },
   },
 
-  integrations: [
-    expressiveCode({
-      plugins: [pluginCollapsibleSections(), pluginLineNumbers(), pluginOpenInPlayground()],
-      themes: ["github-light", "github-dark"],
-      useDarkModeMediaQuery: false,
-      themeCssSelector: (theme) => `[data-theme='${theme.type}']`,
-    }),
-    react(),
-    mdx(),
-  ],
+  integrations: [expressiveCode(), react(), mdx()],
 
   fonts: [
     {

--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -1,0 +1,22 @@
+import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-sections"
+import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers"
+import { pluginOpenInPlayground } from "./src/plugins/expressive-code/open-in-playground.ts"
+
+export default {
+  plugins: [pluginCollapsibleSections(), pluginLineNumbers(), pluginOpenInPlayground()],
+  styleOverrides: {
+    borderColor: ["oklch(27.4% 0.006 286.033)", "oklch(92% 0.004 286.32)"],
+    borderRadius: "calc(0.5rem - 1px)",
+    borderWidth: "1px",
+    codeBackground: ["oklch(21% 0.006 285.885 / 60%)", "oklch(96.7% 0.001 286.375 / 60%)"],
+    codeFontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+    codeFontSize: "0.85rem",
+    codeLineHeight: "1.65",
+    codePaddingBlock: "1.25rem",
+    codePaddingInline: "1.4rem",
+  },
+  themes: ["github-light", "github-dark"],
+  useDarkModeMediaQuery: false,
+  themeCssSelector: (theme) => `[data-theme='${theme.type}']`,
+}

--- a/src/features/api-reference/ApiCodeExample.astro
+++ b/src/features/api-reference/ApiCodeExample.astro
@@ -1,17 +1,13 @@
 ---
+import { Code } from "astro-expressive-code/components"
+
 import type { ApiCodeExample } from "./ApiReference"
-import { docsShikiThemes, getHighlighter } from "@/features/visual-effect/runtime/shiki-singleton"
 
 interface Props {
   example: ApiCodeExample
 }
 
 const { example } = Astro.props
-const highlighter = await getHighlighter()
-const highlighted = highlighter.codeToHtml(example.source, {
-  lang: example.language,
-  themes: docsShikiThemes,
-})
 ---
 
 <article>
@@ -20,27 +16,5 @@ const highlighted = highlighter.codeToHtml(example.source, {
     {example.title && <p class="text-sm text-zinc-500">({example.title})</p>}
   </div>
 
-  <div
-    class="api-example-code overflow-x-auto rounded-lg border border-zinc-200 bg-zinc-100/60 dark:border-zinc-800 dark:bg-zinc-900/60"
-    set:html={highlighted}
-  />
+  <Code code={example.source} lang={example.language} meta="showLineNumbers=false" />
 </article>
-
-<style>
-  .api-example-code :global(.shiki) {
-    min-width: max-content;
-    margin: 0;
-    padding: 1.25rem 1.4rem;
-    background: transparent !important;
-    font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-      monospace;
-    font-size: 0.85rem;
-    line-height: 1.65;
-  }
-
-  :global(.dark) .api-example-code :global(.shiki),
-  :global(.dark) .api-example-code :global(.shiki span) {
-    color: var(--shiki-dark) !important;
-  }
-</style>

--- a/src/features/api-reference/ApiDeclaration.astro
+++ b/src/features/api-reference/ApiDeclaration.astro
@@ -1,23 +1,15 @@
 ---
 import { ExternalLink, Link as LinkIcon } from "@lucide/astro"
+import { Code } from "astro-expressive-code/components"
 
 import type { ApiDeclaration } from "./ApiReference"
 import ApiCodeExample from "./ApiCodeExample.astro"
-import { docsShikiThemes, getHighlighter } from "@/features/visual-effect/runtime/shiki-singleton"
 
 interface Props {
   declaration: ApiDeclaration
 }
 
 const { declaration } = Astro.props
-const highlighter = await getHighlighter()
-const signatureHtml =
-  declaration.signature === undefined
-    ? undefined
-    : highlighter.codeToHtml(declaration.signature, {
-        lang: "typescript",
-        themes: docsShikiThemes,
-      })
 ---
 
 <section id={declaration.anchor} class="scroll-mt-12 py-8">
@@ -62,12 +54,13 @@ const signatureHtml =
   {declaration.commentHtml && <div class="api-comment" set:html={declaration.commentHtml} />}
 
   {
-    signatureHtml && (
+    declaration.signature && (
       <div class="not-prose mt-3">
         <h4 class="mb-1.5 text-base font-semibold text-zinc-600 dark:text-white">Signature</h4>
-        <div
-          class="api-signature overflow-x-auto rounded-lg border border-zinc-200 bg-zinc-100/60 dark:border-zinc-800 dark:bg-zinc-900/60"
-          set:html={signatureHtml}
+        <Code
+          code={declaration.signature}
+          lang="typescript"
+          meta="showLineNumbers=false playground=false"
         />
       </div>
     )
@@ -146,22 +139,5 @@ const signatureHtml =
 
   :global(.dark) .api-comment :global(code) {
     background: var(--color-zinc-800);
-  }
-
-  .api-signature :global(.shiki) {
-    min-width: max-content;
-    margin: 0;
-    padding: 1rem 1.25rem;
-    background: transparent !important;
-    font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-      monospace;
-    font-size: 0.85rem;
-    line-height: 1.65;
-  }
-
-  :global(.dark) .api-signature :global(.shiki),
-  :global(.dark) .api-signature :global(.shiki span) {
-    color: var(--shiki-dark) !important;
   }
 </style>

--- a/src/plugins/expressive-code/open-in-playground.ts
+++ b/src/plugins/expressive-code/open-in-playground.ts
@@ -1,6 +1,6 @@
 import { type ExpressiveCodePlugin, PluginTexts } from "@expressive-code/core"
 import { h, select } from "@expressive-code/core/hast"
-import jsModule from "./open-in-playground/js-module.min"
+import jsModule from "./open-in-playground/js-module.min.ts"
 
 const pluginTexts = new PluginTexts({
   openInPlaygroundButtonTooltip: "Open in the Effect Playground",


### PR DESCRIPTION
## Summary
- render API signatures and examples with the Expressive Code component
- move shared Expressive Code options into the component-compatible root config
- apply the API reference code-block styling across the site

## Verification
- pnpm check
- pnpm test
- pnpm fmt