### PR TITLE
fix: youtube link in footer component

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -294,7 +294,7 @@ const year = new Date().getFullYear()
               </div>
             </Link>
             <Link
-              href="https://www.youtube.com/@EffectTS"
+              href="https://www.youtube.com/@Effect-TS"
               variant="icon"
               aria-label="Subscribe to Effect on YouTube"
               className="text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current YouTube links to the incorrect channel https://www.youtube.com/@EffectTS