### PR TITLE
Install Vite+ for Mixedbread preview cleanup

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -140,6 +140,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
+      - name: Install Vite+
+        uses: voidzero-dev/setup-vp@v1.17.0
+        with:
+          node-manager: false
+
       - name: Install dependencies
         uses: ./.github/actions/setup
 


### PR DESCRIPTION
## Summary
- install Vite+ explicitly in the preview cleanup job
- avoid depending on the checked-out base revision's local setup action for `vp`

This fixes the `vp: command not found` failure from the PR #1449 cleanup run.

## Validation
- `vp fmt --check .github/workflows/preview.yml`
- parsed `.github/workflows/preview.yml` as YAML