### PR TITLE
Rename Effect.catchAll to Effect.catch on landing page

### DIFF
--- a/apps/web/src/features/visual-effect/catalog/effect-catch.ts
+++ b/apps/web/src/features/visual-effect/catalog/effect-catch.ts
@@ -8,7 +8,7 @@ import { EmojiResult } from "../ui/results/emoji"
 import { ErrorResult } from "../ui/results/error"
 
 export const catchExample = defineExample({
-  label: "Effect.catchAll",
+  label: "Effect.catch",
   description:
     "Try one effect, and if it fails, catch the error and run another effect",
   code: {
@@ -17,11 +17,11 @@ export const catchExample = defineExample({
       `|const shoot = shootFirst()
        |const question = askQuestions()
        |
-       |const result = Effect.catchAll(shoot, (error) => question)`,
+       |const result = Effect.catch(shoot, (error) => question)`,
     ),
   },
   resultHighlight: HighlightSelector.Text({
-    text: "Effect.catchAll(shoot, (error) => question)",
+    text: "Effect.catch(shoot, (error) => question)",
   }),
   build: ({ addStep }) => {
     const state = { attempt: 0 }


### PR DESCRIPTION
Renames the `Effect.catchAll` visual-effect example on the landing page to `Effect.catch` (label, code snippet, and result highlight).

Verified with `vp test` (21 tests pass) and `vp run check` (format, lint, typecheck, astro check all clean).

Closes EFF-600