### PR TITLE
Fix segmented control pill alignment in Visual effect controls

### DIFF
--- a/apps/web/src/hooks/useTabsIndicator.ts
+++ b/apps/web/src/hooks/useTabsIndicator.ts
@@ -39,9 +39,13 @@ export const useTabsIndicator = (selection: unknown) => {
 
     const tabListRect = tabListElement.getBoundingClientRect()
     const activeTriggerRect = activeTriggerElement.getBoundingClientRect()
+    // The indicator is positioned relative to the tab list's padding box,
+    // so subtract the border to convert border-box rects to padding-box offsets
+    const { borderLeftWidth, borderTopWidth } = getComputedStyle(tabListElement)
     const nextRect: TabsIndicatorRect = {
-      left: activeTriggerRect.left - tabListRect.left,
-      top: activeTriggerRect.top - tabListRect.top,
+      left:
+        activeTriggerRect.left - tabListRect.left - parseFloat(borderLeftWidth),
+      top: activeTriggerRect.top - tabListRect.top - parseFloat(borderTopWidth),
       width: activeTriggerRect.width,
       height: activeTriggerRect.height,
     }


### PR DESCRIPTION
## Problem

On the home page Visual effect section, the active pill in segmented controls (e.g. the CONCURRENCY `sequential / numbered / unbounded` control) was not centered: it sat 1px low and 1px right of the active trigger, leaving asymmetric padding inside the control.

## Cause

`useTabsIndicator` computed the indicator position by subtracting `getBoundingClientRect()` values, which are relative to the tab list's border box. The indicator is absolutely positioned, so its containing block is the tab list's padding box. Since the list has a 1px border, the pill was offset by exactly the border width on both axes.

## Fix

Subtract the tab list's computed `borderLeftWidth` / `borderTopWidth` in `useTabsIndicator` so the measured rect matches the indicator's containing block (`apps/web/src/hooks/useTabsIndicator.ts`).

## Verification

Regression-checked with Playwright across 320 / 390 / 768 / 1024 / 1440px viewports, clicking through every option of the control at each width: indicator now overlays the active trigger exactly (0px delta on top/left/width/height, including when the control wraps to two rows at narrow widths). `vp check` (format, lint, typecheck) passes.

Closes EFF-601
