### PR TITLE
docs(v4): remove obsolete @effect/platform references

### DIFF
--- a/apps/web/src/content/docs/v4/platform/introduction.mdx
+++ b/apps/web/src/content/docs/v4/platform/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Effect Platform
-description: Build cross-platform applications with unified abstractions for Node.js, Deno, Bun, and browsers using @effect/platform.
+description: Build cross-platform applications with unified abstractions for Node.js, Deno, Bun, and browsers using the platform modules built into Effect.
 sidebar:
   label: Introduction
   order: 0
@@ -8,9 +8,9 @@ sidebar:
 
 import { Aside, Tabs, TabItem, Badge } from "@astrojs/starlight/components"
 
-`@effect/platform` is a library for building platform-independent abstractions in environments such as Node.js, Deno, Bun, and browsers.
+The `effect` package includes platform modules for building platform-independent abstractions in environments such as Node.js, Deno, Bun, and browsers.
 
-With `@effect/platform`, you can integrate abstract services like [FileSystem](/docs/v4/platform/file-system/) or [Terminal](/docs/v4/platform/terminal/) into your program.
+With these modules, you can integrate abstract services like [FileSystem](/docs/v4/platform/file-system/) or [Terminal](/docs/v4/platform/terminal/) into your program.
 When assembling your final application, you can provide specific [layers](/docs/v4/requirements-management/layers/) for the target platform using the corresponding packages:
 
 - `@effect/platform-node` for Node.js or Deno
@@ -31,51 +31,9 @@ The following modules are stable and their documentation is available on this we
 
 ## Installation
 
-To install the **beta** version:
+The platform modules are included in the `effect` package, so no additional installation is required. See [Installation](/docs/v4/getting-started/installation/) for how to install `effect` itself.
 
-<Tabs syncKey="package-manager">
-
-<TabItem label="npm" icon="seti:npm">
-
-```sh showLineNumbers=false
-npm install @effect/platform@rc
-```
-
-</TabItem>
-
-<TabItem label="pnpm" icon="pnpm">
-
-```sh showLineNumbers=false
-pnpm add @effect/platform@rc
-```
-
-</TabItem>
-
-<TabItem label="Yarn" icon="yarn">
-
-```sh showLineNumbers=false
-yarn add @effect/platform@rc
-```
-
-</TabItem>
-
-<TabItem label="Bun" icon="bun">
-
-```sh showLineNumbers=false
-bun add @effect/platform@rc
-```
-
-</TabItem>
-
-<TabItem label="Deno" icon="deno">
-
-```sh showLineNumbers=false
-deno add npm:@effect/platform@rc
-```
-
-</TabItem>
-
-</Tabs>
+Platform-specific packages such as `@effect/platform-node` are only needed to run your program on a concrete platform, as shown in the sections below.
 
 ## Getting Started with Cross-Platform Programming
 

--- a/apps/web/src/content/docs/v4/requirements-management/layers.mdx
+++ b/apps/web/src/content/docs/v4/requirements-management/layers.mdx
@@ -1069,17 +1069,22 @@ Effect.runFork(runnable)
 /*
 {
   _id: 'Cause',
-  _tag: 'Fail',
-  failure: {
-    _tag: 'SystemError',
-    reason: 'NotFound',
-    module: 'FileSystem',
-    method: 'readFile',
-    pathOrDescriptor: 'cache/my-key',
-    syscall: 'open',
-    message: "ENOENT: no such file or directory, open 'cache/my-key'",
-    [Symbol(@effect/platform/Error/PlatformErrorTypeId)]: Symbol(@effect/platform/Error/PlatformErrorTypeId)
-  }
+  failures: [
+    {
+      _tag: 'Fail',
+      error: {
+        _tag: 'PlatformError',
+        reason: {
+          _tag: 'NotFound',
+          module: 'FileSystem',
+          method: 'readFile',
+          pathOrDescriptor: 'cache/my-key',
+          syscall: 'open',
+          cause: [Error: ENOENT: no such file or directory, open 'cache/my-key']
+        }
+      }
+    }
+  ]
 }
 */
 ```


### PR DESCRIPTION
The v4 docs still described and installed `@effect/platform`, which has no v4 release: its modules (`FileSystem`, `Path`, `Terminal`, `PlatformLogger`) now ship in the `effect` package itself.

## Changes

- **`platform/introduction.mdx`**: rewrote the intro and frontmatter description to say the platform modules are built into `effect`, and replaced the `npm install @effect/platform@rc` tab group with a note that no extra package is needed (platform-specific packages like `@effect/platform-node` are still installed in the sections below).
- **`requirements-management/layers.mdx`**: replaced the stale v3 error output (`SystemError` with `Symbol(@effect/platform/Error/PlatformErrorTypeId)`) with the actual v4 `Cause` shape, captured by running the snippet against `effect@4.0.0-beta.104`.

## Audit notes

Swept all `@effect/*` references across `apps/web/src/content/docs/v4` and verified each against npm dist-tags: `@effect/platform-node`, `@effect/platform-bun`, `@effect/platform-browser`, and `@effect/opentelemetry` all have v4 `rc`/`beta` releases, so those references are current. All code snippets already used the v4 import style. These two files were the only ones with obsolete references.

## Validation

- `pnpm doctest` on both changed files: 19/19 pass.
- Full doctest run: only pre-existing failures in `data-types/datetime.mdx` (6 timezone-dependent assertions that also fail on clean `main` in this environment).
- `astro build` completes successfully.
- `vp fmt --check` passes on changed files.

Closes EFF-620

🤖 Generated with [Claude Code](https://claude.com/claude-code)
