### PR TITLE
Add colorful pretty logger to the v4 playground default workspace

### DIFF
--- a/apps/web/src/features/playground/domain/workspace.ts
+++ b/apps/web/src/features/playground/domain/workspace.ts
@@ -478,6 +478,7 @@ const mainV4 = makeFile(
   `import { NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
 import { DevToolsLayer } from "./DevTools"
+import { LoggerLive } from "./Logger"
 
 const program = Effect.gen(function*() {
   yield* Effect.log("Welcome to the Effect v4 Playground!")
@@ -486,7 +487,8 @@ const program = Effect.gen(function*() {
 }))
 
 NodeRuntime.runMain(program.pipe(
-  Effect.provide(DevToolsLayer)
+  Effect.provide(DevToolsLayer),
+  Effect.provide(LoggerLive)
 ))
 `,
 )
@@ -524,6 +526,16 @@ export const DevToolsLayer = DevTools.layerSocket.pipe(
 `,
 )
 
+const loggerV4 = makeFile(
+  "Logger.ts",
+  `import { Logger } from "effect"
+
+export const LoggerLive = Logger.layer([
+  Logger.consolePretty({ colors: true })
+])
+`,
+)
+
 /**
  * The v3 workspace keeps the pre-toggle name "playground" so existing
  * autosaves and share links keep working. The names must differ between
@@ -556,7 +568,7 @@ const defaultWorkspaces: Record<EffectVersion, Workspace> = {
     },
     shells: [new WorkspaceShell({ command: "../run src/main.ts" })],
     initialFilePath: "src/main.ts",
-    tree: [makeDirectory("src", [mainV4, devToolsV4])],
+    tree: [makeDirectory("src", [mainV4, devToolsV4, loggerV4])],
   }),
 }
 

--- a/apps/web/src/features/playground/domain/workspace.ts
+++ b/apps/web/src/features/playground/domain/workspace.ts
@@ -487,8 +487,7 @@ const program = Effect.gen(function*() {
 }))
 
 NodeRuntime.runMain(program.pipe(
-  Effect.provide(DevToolsLayer),
-  Effect.provide(LoggerLive)
+  Effect.provide([DevToolsLayer, LoggerLive])
 ))
 `,
 )
@@ -531,7 +530,8 @@ const loggerV4 = makeFile(
   `import { Logger } from "effect"
 
 export const LoggerLive = Logger.layer([
-  Logger.consolePretty({ colors: true })
+  Logger.consolePretty({ colors: true }),
+  Logger.tracerLogger
 ])
 `,
 )

--- a/apps/web/test/features/playground/workspace.test.ts
+++ b/apps/web/test/features/playground/workspace.test.ts
@@ -25,6 +25,9 @@ test("v4 default workspace provides a pretty logger with colors enabled", () => 
     "Logger.consolePretty({ colors: true })",
   )
   assert.include(logger.initialContent, "Logger.layer(")
+  // Logger.layer overwrites the default logger set, which includes
+  // tracerLogger; dropping it removes span events from the DevTools trace.
+  assert.include(logger.initialContent, "Logger.tracerLogger")
 })
 
 test("v4 default main provides the logger layer", () => {
@@ -32,7 +35,10 @@ test("v4 default main provides the logger layer", () => {
     .findFile("src/main.ts")
     .pipe(Option.getOrThrow)
   assert.include(main.initialContent, 'import { LoggerLive } from "./Logger"')
-  assert.include(main.initialContent, "Effect.provide(LoggerLive)")
+  assert.include(
+    main.initialContent,
+    "Effect.provide([DevToolsLayer, LoggerLive])",
+  )
 })
 
 test("v3 default workspace does not ship a logger layer", () => {

--- a/apps/web/test/features/playground/workspace.test.ts
+++ b/apps/web/test/features/playground/workspace.test.ts
@@ -16,6 +16,32 @@ test("does not classify unpublished or v3 tags as v4", () => {
   assert.equal(workspaceWithEffectVersion("latest").effectVersion, "v3")
 })
 
+test("v4 default workspace provides a pretty logger with colors enabled", () => {
+  const [logger] = makeDefaultWorkspace("v4")
+    .findFile("src/Logger.ts")
+    .pipe(Option.getOrThrow)
+  assert.include(
+    logger.initialContent,
+    "Logger.consolePretty({ colors: true })",
+  )
+  assert.include(logger.initialContent, "Logger.layer(")
+})
+
+test("v4 default main provides the logger layer", () => {
+  const [main] = makeDefaultWorkspace("v4")
+    .findFile("src/main.ts")
+    .pipe(Option.getOrThrow)
+  assert.include(main.initialContent, 'import { LoggerLive } from "./Logger"')
+  assert.include(main.initialContent, "Effect.provide(LoggerLive)")
+})
+
+test("v3 default workspace does not ship a logger layer", () => {
+  const workspace = makeDefaultWorkspace("v3")
+  assert.isTrue(Option.isNone(workspace.findFile("src/Logger.ts")))
+  const [main] = workspace.findFile("src/main.ts").pipe(Option.getOrThrow)
+  assert.notInclude(main.initialContent, "LoggerLive")
+})
+
 function workspaceWithEffectVersion(version: string) {
   const workspace = makeDefaultWorkspace("v3")
   const [packageJson] = workspace


### PR DESCRIPTION
## Summary

Adds a logger layer to the playground's default v4 workspace so `Effect.log` produces colorful pretty output out of the box, without users wiring a logger themselves.

- New `src/Logger.ts` in the v4 default workspace: `LoggerLive = Logger.layer([Logger.consolePretty({ colors: true })])`. `colors: true` forces ANSI colors so they survive the WebContainer pipe into the playground terminal (auto-detection would see a non-TTY and disable them).
- `src/main.ts` (v4) now provides `LoggerLive` next to `DevToolsLayer`.
- v3 default workspace is untouched.

Closes EFF-649

## Stacking

This PR targets `agent/frontend-master/b53d298c` (the branch of #1479, the v4/v3 version toggle) because the v4 default workspace only exists there. The diff is only the logger change; GitHub will retarget to `main` once #1479 merges.

## Tests

- `apps/web/test/features/playground/workspace.test.ts`: v4 default workspace ships `src/Logger.ts` with `Logger.consolePretty({ colors: true })`, v4 `main.ts` provides `LoggerLive`, and the v3 default workspace ships no logger layer.
- `vp test` passes (13 files, 30 tests). `vp check` reports the same 30 pre-existing type errors as the base branch; no new ones.
