### PR TITLE
Fix playground formatting loop

### DIFF
--- a/apps/web/src/features/playground/atoms/workspace.ts
+++ b/apps/web/src/features/playground/atoms/workspace.ts
@@ -432,13 +432,6 @@ function setupWorkspaceFormatters(workspace: Workspace) {
     const toaster = yield* Toaster
     const container = yield* WebContainer
 
-    monaco.editor.addEditorAction({
-      id: "format",
-      label: "Format",
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
-      run: (editor) => editor.getAction("editor.action.formatDocument")?.run(),
-    })
-
     const installedFormatters = new Map<string, InstalledFormatter>()
 
     yield* Effect.addFinalizer(() =>

--- a/apps/web/src/features/playground/services/monaco.ts
+++ b/apps/web/src/features/playground/services/monaco.ts
@@ -125,6 +125,19 @@ export class Monaco extends Context.Service<Monaco>()("app/Monaco", {
           (editor) => Effect.sync(() => editor.dispose()),
         )
 
+        yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            editor.addAction({
+              id: "format",
+              label: "Format",
+              keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
+              run: () =>
+                editor.getAction("editor.action.formatDocument")?.run(),
+            }),
+          ),
+          (action) => Effect.sync(() => action.dispose()),
+        )
+
         /**
          * Loads the specified model into the editor.
          */

--- a/apps/web/src/features/playground/services/webcontainer.ts
+++ b/apps/web/src/features/playground/services/webcontainer.ts
@@ -251,9 +251,9 @@ export class WebContainer extends Context.Service<WebContainer>()(
        * Updates an existing file without recreating it if it was removed outside
        * the editor.
        */
-      function updateFile(path: string, content: string, language: string) {
+      function updateFile(path: string, content: string) {
         return readFileString(path).pipe(
-          Effect.andThen(writeFile(path, content, language)),
+          Effect.andThen(writeFileString(path, content)),
         )
       }
 
@@ -746,9 +746,9 @@ export class WebContainer extends Context.Service<WebContainer>()(
           workspace: workspaceRef,
           spawn: spawnInWorkspace,
           run: runInWorkspace,
-          writeFile: (path: string, content: string, language: string) =>
+          writeFile: (path: string, content: string, _language: string) =>
             mutationLock.withPermit(
-              updateFile(path, content, language).pipe(
+              updateFile(path, content).pipe(
                 Effect.tap(() =>
                   Effect.sync(() => localWrites.set(path, content)),
                 ),


### PR DESCRIPTION
## Summary
- prevent delayed editor saves from writing stale content back into Monaco
- scope the format-on-save action to the Monaco editor lifecycle
- dispose the action when the editor is released

## Validation
- `vp test` (14 files, 32 tests passed)
- `vp check` formatting and lint passed; type checking remains blocked by the pre-existing `apps/web/src/features/open-graph/Fonts.ts:45` error for `--font-og-inter`