### PR TITLE
Add pretty logger to v4 playground

### DIFF
--- a/apps/web/src/features/playground/domain/workspace.ts
+++ b/apps/web/src/features/playground/domain/workspace.ts
@@ -517,10 +517,11 @@ const devToolsV4 = makeFile(
   "DevTools.ts",
   `import { NodeSocket } from "@effect/platform-node"
 import { DevTools } from "effect/unstable/devtools"
-import { Layer } from "effect"
+import { Layer, Logger } from "effect"
 
 export const DevToolsLayer = DevTools.layerSocket.pipe(
-  Layer.provide(NodeSocket.layerNet({ port: 34437 }))
+  Layer.provide(NodeSocket.layerNet({ port: 34437 })),
+  Layer.provideMerge(Logger.layer([Logger.consolePretty(), Logger.tracerLogger]))
 )
 `,
 )

--- a/apps/web/test/features/playground/workspace.test.ts
+++ b/apps/web/test/features/playground/workspace.test.ts
@@ -16,6 +16,18 @@ test("does not classify unpublished or v3 tags as v4", () => {
   assert.equal(workspaceWithEffectVersion("latest").effectVersion, "v3")
 })
 
+test("includes the pretty logger in the v4 DevTools layer", () => {
+  const workspace = makeDefaultWorkspace("v4")
+  const [devTools] = workspace
+    .findFile("src/DevTools.ts")
+    .pipe(Option.getOrThrow)
+
+  assert.include(
+    devTools.initialContent,
+    "Logger.layer([Logger.consolePretty(), Logger.tracerLogger])",
+  )
+})
+
 function workspaceWithEffectVersion(version: string) {
   const workspace = makeDefaultWorkspace("v3")
   const [packageJson] = workspace

--- a/apps/web/test/features/playground/workspace.test.ts
+++ b/apps/web/test/features/playground/workspace.test.ts
@@ -16,18 +16,6 @@ test("does not classify unpublished or v3 tags as v4", () => {
   assert.equal(workspaceWithEffectVersion("latest").effectVersion, "v3")
 })
 
-test("includes the pretty logger in the v4 DevTools layer", () => {
-  const workspace = makeDefaultWorkspace("v4")
-  const [devTools] = workspace
-    .findFile("src/DevTools.ts")
-    .pipe(Option.getOrThrow)
-
-  assert.include(
-    devTools.initialContent,
-    "Logger.layer([Logger.consolePretty(), Logger.tracerLogger])",
-  )
-})
-
 function workspaceWithEffectVersion(version: string) {
   const workspace = makeDefaultWorkspace("v3")
   const [packageJson] = workspace


### PR DESCRIPTION
## Summary

- add the console pretty logger to the v4 playground's DevTools layer
- retain the tracer logger when replacing the active logger set

## Impact

Logs in new v4 playground workspaces are easier to scan while trace logging continues to feed the integrated developer tools.

## Validation

- `nix develop -c pnpm exec vp test apps/web/test/features/playground` (6 tests passed)
- `nix develop -c pnpm exec vp run check`
- `nix develop -c pnpm exec vp run test` (32 tests passed)

Closes EFF-658