### PR TITLE
docs: remove unused `Console` import in tracking-fibers.mdx

### DIFF
--- a/apps/web/src/content/docs/v4/observability/tracking-fibers.mdx
+++ b/apps/web/src/content/docs/v4/observability/tracking-fibers.mdx
@@ -18,7 +18,7 @@ A `FiberSet<A, E>` collects fibers so they can be observed, joined, or interrupt
 In this example, we periodically monitor the number of fibers running in the application while calculating a Fibonacci number. The program forks two child fibers for every recursive step, adding each to a shared `FiberSet`, while a separate monitor fiber logs the set's size on a schedule until the calculation finishes.
 
 ```ts twoslash import.meta.vitest name="monitoring-fiber-count"
-import { Console, Effect, Fiber, FiberSet, Schedule } from "effect"
+import { Effect, Fiber, FiberSet, Schedule } from "effect"
 
 // Main program that monitors fibers while calculating a Fibonacci number
 const program = Effect.gen(function* () {


### PR DESCRIPTION
Removed unused import of Console from the tracking-fibers.mdx file.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
