### PR TITLE
docs: list Rolldown among bundlers with deep scope analysis

### DIFF
--- a/apps/web/src/content/docs/v3/getting-started/importing-effect.mdx
+++ b/apps/web/src/content/docs/v3/getting-started/importing-effect.mdx
@@ -99,6 +99,7 @@ Named imports may generate tree shaking issues when a bundler doesn't support de
 
 Here are some bundlers that support deep scope analysis and thus don't have issues with named imports:
 
+- Rolldown
 - Rollup
 - Webpack 5+
 

--- a/apps/web/src/content/docs/v3/micro/effect-users.mdx
+++ b/apps/web/src/content/docs/v3/micro/effect-users.mdx
@@ -47,6 +47,7 @@ Named imports may generate tree shaking issues when a bundler doesn't support de
 
 Here are some bundlers that support deep scope analysis and thus don't have issues with named imports:
 
+- Rolldown
 - Rollup
 - Webpack 5+
 

--- a/apps/web/src/content/docs/v3/micro/new-users.mdx
+++ b/apps/web/src/content/docs/v3/micro/new-users.mdx
@@ -95,6 +95,7 @@ Named imports may generate tree shaking issues when a bundler doesn't support de
 
 Here are some bundlers that support deep scope analysis and thus don't have issues with named imports:
 
+- Rolldown
 - Rollup
 - Webpack 5+
 

--- a/apps/web/src/content/docs/v4/getting-started/importing-effect.mdx
+++ b/apps/web/src/content/docs/v4/getting-started/importing-effect.mdx
@@ -105,6 +105,7 @@ Named imports may generate tree shaking issues when a bundler doesn't support de
 
 Here are some bundlers that support deep scope analysis and thus don't have issues with named imports:
 
+- Rolldown
 - Rollup
 - Webpack 5+
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds Rolldown to the list of bundlers that support deep scope analysis, alongside Rollup and Webpack 5+.

Rolldown is the bundler Vite is moving to, so Vite users — likely a large share of the people who reach this page — currently find their bundler unlisted. The natural reading of that omission is that they should switch to namespace imports, giving up the ergonomics of named imports for no actual benefit.

The passage appears on four pages, all updated here:

- `apps/web/src/content/docs/v4/getting-started/importing-effect.mdx`
- `apps/web/src/content/docs/v3/getting-started/importing-effect.mdx`
- `apps/web/src/content/docs/v3/micro/effect-users.mdx`
- `apps/web/src/content/docs/v3/micro/new-users.mdx`

Content-only change; no code or configuration touched.

## Related

- Related Issue #
- Closes #