### PR TITLE
fix: correct Effect.validate landing page snippet

### DIFF
--- a/apps/web/src/features/visual-effect/catalog/effect-validate.ts
+++ b/apps/web/src/features/visual-effect/catalog/effect-validate.ts
@@ -48,8 +48,8 @@ export const validateExample = defineExample({
        |const vibes = checkVibes(password)
        |
        |const result = Effect.validate(
-       |  [iceCream, battery, popsicle, toad, lollipop],
-       |  performLick
+       |  [length, complexity, vibes],
+       |  identity
        |)`,
     ),
   },


### PR DESCRIPTION
## Problem

The `Effect.validate` card on the landing page (Error Handling tab) displays a code snippet that was copy-pasted from the `Effect.partition` example. It shows `[iceCream, battery, popsicle, toad, lollipop]` and `performLick` — names from the licking demo that are never defined in this example:

```ts
const length = checkLength(password)
const complexity = checkComplexity(password)
const vibes = checkVibes(password)

const result = Effect.validate(
  [iceCream, battery, popsicle, toad, lollipop],  // ← from effect-partition
  performLick                                      // ← from effect-partition
)
```

The three `const`s declared directly above are unused by the snippet, and the animation runs something else entirely: the example's `build` validates the three password checks.

## Fix

Show the array and combining function the example actually executes:

```ts
const result = Effect.validate(
  [length, complexity, vibes],
  identity
)
```

This matches `Effect.validate([lengthStep, complexityStep, vibesStep], identity)` in the `build` function below it, and follows the same convention as the other catalog entries (e.g. `effect-all-short-circuit` displays `Effect.all([balance, credit, payment])` mirroring its own build).

`identity` is correct for the v4 signature `validate(elements, f, options?)`: each element is already an `Effect`, so `f = identity` yields `Effect<Array<A>, NonEmptyArray<E>>` — every check runs and all failures are accumulated, which is exactly the "accumulate validation errors instead of short-circuiting" behavior the card describes.

The line count is unchanged, so `resultHighlight: LineRange({ startLine: 5, endLine: 8 })` still covers the `Effect.validate(...)` call and the three `checkX(password)` text highlights still resolve.

## Verification

- `vp run lint` — 0 warnings, 0 errors
- `vp run fmt` — all files correctly formatted
- `vp run check` — 0 type errors; `astro check` 0 errors / 0 warnings / 0 hints
- `vp test` — 286 tests passed
- Ran the dev server and stepped through Error Handling → `Effect.validate`: the snippet renders correctly, and the step + result highlights animate as expected.
