### PR TITLE
Fix TWIE 133 Socket bullet: pull-based Socket API, not new WebSocket support

### DIFF
--- a/apps/web/src/content/blog/this-week-in-effect/133/index.mdx
+++ b/apps/web/src/content/blog/this-week-in-effect/133/index.mdx
@@ -43,7 +43,7 @@ generation.
 
 - **Native PostgreSQL client**: Replaced the `pg` dependency with a native `PgProtocol` client in `@effect/sql-pg`, reducing external dependencies and improving control over the connection lifecycle.
 
-- **WebSocket support**: Added WebSocket client support across runtimes (Node, Bun, Deno, browser), and fixed the Node platform writing HTTP responses onto already-upgraded WebSocket connections.
+- **Pull-based Sockets**: Reworked the Socket API around a pull-based reader with end-to-end backpressure, making reconnects as simple as `Effect.retry`, unified the WebSocket client interface across runtimes (Node, Bun, Deno, browser) with typed handshake headers, and fixed the Node platform writing HTTP responses onto already-upgraded WebSocket connections.
 
 - **Schema**: Added partial matching to `Schema.TaggedUnion`, optimized synchronous schema parsing for better performance, and fixed `Schema` class equivalence derivation.
 


### PR DESCRIPTION
Closes EFF-976

TWIE 133 presented WebSocket client support as newly added, but WebSocket support has existed in Effect for a while. Verified against the upstream PRs that landed that week:

- [Effect-TS/effect#7487](https://github.com/Effect-TS/effect/pull/7487) reworked the Socket API around a pull-based reader with end-to-end backpressure, making reconnects as simple as `Effect.retry`. This is the actual headline change.
- [Effect-TS/effect#7477](https://github.com/Effect-TS/effect/pull/7477) unified the WebSocket client interface across runtimes and added typed handshake headers. It did not add WebSocket support from scratch.
- [Effect-TS/effect#7457](https://github.com/Effect-TS/effect/pull/7457) is the Node platform fix for HTTP responses written onto upgraded WebSocket connections, kept in the same bullet.

The bullet is now titled "Pull-based Sockets" and leads with the API rework.
