### PR TITLE
docs(v4): document Oxlint integration

### DIFF
--- a/apps/web/src/content/docs/v4/getting-started/devtools.mdx
+++ b/apps/web/src/content/docs/v4/getting-started/devtools.mdx
@@ -7,13 +7,13 @@ sidebar:
 
 import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components"
 
-Effect provides powerful development tools to enhance your coding experience and help you write safer, more maintainable code. These tools integrate directly into your editor, providing real-time feedback, intelligent refactors, and helpful diagnostics.
+Effect provides powerful development tools to enhance your coding experience and help you write safer, more maintainable code. These tools integrate directly into your editor, providing real-time feedback to you and your agents, intelligent refactors, and helpful diagnostics.
 
 ## Effect LSP (`@effect/tsgo`)
 
 The Effect Language Service extends your editor with Effect-specific features. It analyzes your Effect code and provides intelligent assistance through diagnostics, quick info, completions, and automated refactors.
 
-The language service ships as `@effect/tsgo`: a build of [TypeScript-Go](https://github.com/microsoft/TypeScript-Go) (the new Go-based TypeScript compiler) with the Effect diagnostics layer built in. It is a **superset** of plain `tsgo`; use `@effect/tsgo` as your sole TypeScript language server rather than running both side by side, since that produces duplicate diagnostics.
+The language service ships as `@effect/tsgo`: a build of [TypeScript-Go](https://github.com/microsoft/TypeScript-Go) (the new Go-based TypeScript compiler) with the Effect diagnostics layer built in. `@effect/tsgo` acts as a CLI to perform the installation of the modified TypeScript-Go.
 
 It works in editors that support the standard TypeScript LSP, such as Code, Cursor, Zed, NVim, etc.
 
@@ -26,6 +26,12 @@ npx @effect/tsgo setup
 ```
 
 This guides you through adding the dependency, configuring your `tsconfig.json`, adjusting plugin options, and any editor configuration needed to activate the LSP.
+
+You can also ask your LLM agents to directly perform the install by pointing them to the CLI setup and install readme:
+
+```sh showLineNumbers=false
+Install and enable https://github.com/Effect-TS/tsgo in this project using npx @effect/tsgo setup --help
+```
 
 To set it up manually instead:
 
@@ -87,7 +93,55 @@ To set it up manually instead:
    }
    ```
 
-3. Ensure your editor uses the workspace TypeScript version:
+3. Add the following script to your `package.json` to ensure that the modified TypeScript version is installed upon restarts:
+
+   ```json title="package.json"
+   {
+     "scripts": {
+       "prepare": "effect-tsgo patch"
+     }
+   }
+   ```
+
+   and then run your package manager install command
+
+   <Tabs syncKey="package-manager">
+
+   <TabItem label="npm" icon="seti:npm">
+
+   ```sh showLineNumbers=false
+   npm install
+   ```
+
+   </TabItem>
+
+   <TabItem label="pnpm" icon="pnpm">
+
+   ```sh showLineNumbers=false
+   pnpm install
+   ```
+
+   </TabItem>
+
+   <TabItem label="Yarn" icon="seti:yarn">
+
+   ```sh showLineNumbers=false
+   yarn install
+   ```
+
+   </TabItem>
+
+   <TabItem label="Bun" icon="bun">
+
+   ```sh showLineNumbers=false
+   bun install
+   ```
+
+   </TabItem>
+
+   </Tabs>
+
+4. Ensure your editor uses the workspace TypeScript version:
 
    This step is critical for the language service to function properly. The plugin must run on the TypeScript version installed in your project, not the one bundled with your editor.
 
@@ -97,7 +151,7 @@ To set it up manually instead:
      status bar, and selecting "Use Workspace Version".
    </Aside>
 
-4. You're ready to play!
+5. You're ready to play!
 
    Writing the following code in a file.ts inside your project, should result in an error diagnostic appearing, saying that Effect's must be yielded or assigned to a variable:
 
@@ -162,27 +216,131 @@ To see the full list of options and features, please visit the [README from the 
 
 While LSPs only activate during editing sessions, you may want to catch diagnostics during your build process.
 
-Usually that's done through linting rules, but since almost all of the Effect diagnostics relies on types, that would mean enabling type-aware linting, which means performing type checking again on the project files.
+Once installing `@effect/tsgo`, the Effect diagnostics will be treated as they were regular TypeScript diagnostics, so they can be accessed and read by your LLM agents with ease.
 
-To solve this, `@effect/tsgo` allows you to patch your local TypeScript installation, so diagnostics are emitted while performing type checking.
+## Oxlint
 
-To enable it run the following command to modify your local TypeScript installation:
+Be sure to have installed both Oxlint and the Effect TypeScript-Go integration. The following commands will install the latest versions of both:
+
+<Tabs syncKey="package-manager">
+
+   <TabItem label="npm" icon="seti:npm">
 
 ```sh showLineNumbers=false
-effect-tsgo patch
+npm install @effect/tsgo oxlint oxlint-tsgolint --save-dev
 ```
 
-To make this automatic for all developers, add it to your `package.json`:
+   </TabItem>
+
+   <TabItem label="pnpm" icon="pnpm">
+
+```sh showLineNumbers=false
+pnpm add -D @effect/tsgo oxlint oxlint-tsgolint
+```
+
+   </TabItem>
+
+   <TabItem label="Yarn" icon="seti:yarn">
+
+```sh showLineNumbers=false
+yarn add --dev @effect/tsgo oxlint oxlint-tsgolint
+```
+
+   </TabItem>
+
+   <TabItem label="Bun" icon="bun">
+
+```sh showLineNumbers=false
+bun add --dev @effect/tsgo oxlint oxlint-tsgolint
+```
+
+   </TabItem>
+
+   </Tabs>
+
+Update the scripts section of your `package.json` to include the following:
 
 ```json title="package.json"
 {
   "scripts": {
-    "prepare": "effect-tsgo patch"
+    "prepare": "effect-tsgo patch --oxlint"
   }
 }
 ```
 
-This ensures the language service runs during compilation with the standard `tsc` command.
+This will patch Oxlint to use the Effect TypeScript-Go integration after any package installation. To avoid patching TypeScript, you can use the `--no-typescript` flag: `effect-tsgo patch --no-typescript --oxlint`. This will patch Oxlint to use the Effect TypeScript-Go integration without patching TypeScript.
+
+When you have the Effect LSP enabled as well, we recommend setting `diagnostics` to `false` in the LSP plugin settings so that Effect diagnostics are reported only by Oxlint and do not appear twice:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnostics": false
+      }
+    ]
+  }
+}
+```
+
+Run your package manager's install command to install the dependencies and execute the prepare script that patches Oxlint.
+
+<Tabs syncKey="package-manager">
+
+<TabItem label="npm" icon="seti:npm">
+
+```sh showLineNumbers=false
+npm install
+```
+
+</TabItem>
+
+<TabItem label="pnpm" icon="pnpm">
+
+```sh showLineNumbers=false
+pnpm install
+```
+
+</TabItem>
+
+<TabItem label="Yarn" icon="seti:yarn">
+
+```sh showLineNumbers=false
+yarn install
+```
+
+</TabItem>
+
+<TabItem label="Bun" icon="bun">
+
+```sh showLineNumbers=false
+bun install
+```
+
+</TabItem>
+
+</Tabs>
+
+Effect rules require Oxlint's type-aware mode and the `effecttsgo` plugin. The recommended preset enables both and configures the recommended Effect rules. Use the schema shipped with `@effect/tsgo` for validation and completions:
+
+```json title=".oxlintrc.json"
+{
+  "$schema": "./node_modules/@effect/tsgo/oxlint-schema.json",
+  "extends": ["./node_modules/@effect/tsgo/oxlint-presets/recommended.json"]
+}
+```
+
+Rules can also be enabled via a .ts Oxlint/Vite Plus config, the presets are available through:
+
+```ts
+import { recommended } from "@effect/tsgo/oxlint-presets"
+```
+
+## Vite Plus
+
+Vite Plus provides an internally bundled version of Oxlint and Oxlint-TSGoLint, following the install procedure for Oxlint will work as well as is for Vite Plus monorepos.
 
 ## VS Code / Cursor Extension
 

--- a/apps/web/src/content/docs/v4/getting-started/devtools.mdx
+++ b/apps/web/src/content/docs/v4/getting-started/devtools.mdx
@@ -336,6 +336,11 @@ Rules can also be enabled via a .ts Oxlint/Vite Plus config, the presets are ava
 
 ```ts
 import { recommended } from "@effect/tsgo/oxlint-presets"
+import { defineConfig } from "oxlint"
+
+export default defineConfig({
+  extends: [recommended],
+})
 ```
 
 ## Vite Plus


### PR DESCRIPTION
## Summary

- clarify how `@effect/tsgo` installs and patches TypeScript-Go
- document automated setup guidance for LLM agents
- add Oxlint and Vite Plus integration instructions, including recommended presets

## Validation

- `vp test` (286 tests passed)
- `vp run build`
- `vp check` formatting passed; type checking reports 11 existing errors in `Fonts.ts` and `docs-sections.ts`
- `vp run doctest:file` reports 803 passing tests and 10 existing failures in schema/platform docs