### PR TITLE
Prevent theme toggle layout shift

### DIFF
--- a/apps/web/src/components/navigation/NavigationDesktopActions.astro
+++ b/apps/web/src/components/navigation/NavigationDesktopActions.astro
@@ -24,7 +24,7 @@ const { showThemeToggle = false } = Astro.props
     <>
       <div class="h-4.5 w-px bg-zinc-200 dark:bg-zinc-700" aria-hidden="true" />
       <ThemeToggle
-        client:only="react"
+        client:load
         className="text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
       />
     </>

--- a/apps/web/src/components/navigation/NavigationMobileMenu.astro
+++ b/apps/web/src/components/navigation/NavigationMobileMenu.astro
@@ -20,7 +20,7 @@ const { primaryLinks, socialLinks, activeSlug, showThemeToggle = false } = Astro
   {
     showThemeToggle && (
       <ThemeToggle
-        client:only="react"
+        client:load
         className="h-10 w-10 text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white md:hidden"
       />
     )

--- a/apps/web/src/components/ui/ThemeToggle.tsx
+++ b/apps/web/src/components/ui/ThemeToggle.tsx
@@ -2,7 +2,6 @@ import { useAtomSet, useAtomValue } from "@effect/atom-react"
 import { Check, Monitor, Moon, Sun } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import {
-  isDarkAtom,
   selectThemeAtom,
   themeAtom,
   type Theme,
@@ -23,7 +22,6 @@ export default function ThemeToggle({
   const menuRef = useRef<HTMLDivElement>(null)
 
   const theme = useAtomValue(themeAtom)
-  const isDark = useAtomValue(isDarkAtom)
   const selectTheme = useAtomSet(selectThemeAtom)
 
   // Close menu on outside click or Escape
@@ -55,11 +53,8 @@ export default function ThemeToggle({
         aria-label="Change theme"
         className={`flex items-center justify-center transition-colors ${className}`}
       >
-        {isDark ? (
-          <Moon size={20} aria-hidden="true" />
-        ) : (
-          <Sun size={20} aria-hidden="true" />
-        )}
+        <Sun size={20} className="dark:hidden" aria-hidden="true" />
+        <Moon size={20} className="hidden dark:block" aria-hidden="true" />
       </button>
 
       {open && (


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed an annoying layout shift caused by the theme toggle switch not being available until client-side hydration. This PR makes both icons rendered on the server and allows Astro to quickly decide which one to render at initialization time (it toggled `.dark` class on the `html` element). The icon's visibility state gets toggled with the CSS classes now and doesn't need an atom subscription.

## Related

N/A