### PR TITLE
Fix Cloudflare deployment workflows

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -239,5 +239,9 @@ runs:
       env:
         TRAFFIC_MODE: ${{ inputs.cloudflare-traffic-mode }}
       run: |
-        echo "::error::Deployment validation failed in traffic mode '$TRAFFIC_MODE'. Run the protected Rollback Production workflow with the recorded known-good commit, API snapshot, and previous traffic mode."
-        echo "::error::A rollback that removes Custom Domains requires the runbook's manual Vercel rollback procedure."
+        if [[ "$TRAFFIC_MODE" == "workers-dev" ]]; then
+          echo "::error::Deployment validation failed for the private workers.dev deployment. Production traffic was not changed; fix the validation failure and rerun the deployment."
+        else
+          echo "::error::Deployment validation failed in traffic mode '$TRAFFIC_MODE'. Run the protected Rollback Production workflow with the recorded known-good commit, API snapshot, and previous traffic mode."
+          echo "::error::A rollback that removes Custom Domains requires the runbook's manual Vercel rollback procedure."
+        fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.merged && github.event.pull_request.merge_commit_sha || github.event.pull_request.base.sha }}
 
       - name: Install dependencies
         uses: ./.github/actions/setup
@@ -118,7 +118,7 @@ jobs:
           MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
-          WEBSITE_REVISION: ${{ github.event.pull_request.base.sha }}
+          WEBSITE_REVISION: ${{ github.event.pull_request.merged && github.event.pull_request.merge_commit_sha || github.event.pull_request.base.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete Mixedbread preview store

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -52,7 +52,10 @@ const Website = (storeId: Input<string | Redacted.Redacted<string>>) =>
           workspaces: "auto" as const,
         },
         astro: { output: "static" as const },
-        assets: { htmlHandling: "drop-trailing-slash" as const },
+        assets: {
+          htmlHandling: "drop-trailing-slash" as const,
+          notFoundHandling: "404-page" as const,
+        },
         ...(stage === "prod"
           ? {
               domain: domainEnabled

--- a/apps/web/scripts/verify-cloudflare-deployment.d.mts
+++ b/apps/web/scripts/verify-cloudflare-deployment.d.mts
@@ -1,0 +1,14 @@
+export function retry<A>(
+  label: string,
+  operation: (attempt: number) => Promise<A>,
+  options?: {
+    readonly timeoutMs?: number
+    readonly delayMs?: number
+  },
+): Promise<A>
+
+export function withCacheBuster(
+  url: string | URL,
+  nonce: string,
+  attempt: number,
+): URL

--- a/apps/web/scripts/verify-cloudflare-deployment.mjs
+++ b/apps/web/scripts/verify-cloudflare-deployment.mjs
@@ -1,4 +1,5 @@
-const [baseUrlArgument, trafficMode, expectedRevision] = process.argv.slice(2)
+import { pathToFileURL } from "node:url"
+
 const trafficModes = new Set([
   "workers-dev",
   "routes",
@@ -6,36 +7,35 @@ const trafficModes = new Set([
   "custom-domains",
 ])
 
-if (baseUrlArgument === undefined || !trafficModes.has(trafficMode)) {
-  console.error(
-    "Usage: verify-cloudflare-deployment.mjs <base-url> <traffic-mode>",
-  )
-  process.exit(1)
-}
-
-const baseUrl = new URL(baseUrlArgument)
-if (baseUrl.protocol !== "https:") {
-  console.error(`Deployment URL must use HTTPS: ${baseUrl.href}`)
-  process.exit(1)
-}
-
-const retry = async (label, operation) => {
-  const deadline = Date.now() + 2 * 60_000
+export const retry = async (
+  label,
+  operation,
+  { timeoutMs = 2 * 60_000, delayMs = 10_000 } = {},
+) => {
+  const deadline = Date.now() + timeoutMs
+  let attempt = 0
   let lastError = new Error(
     `${label} did not complete before the retry deadline`,
   )
   while (Date.now() < deadline) {
     try {
-      return await operation()
+      return await operation(attempt)
     } catch (error) {
       lastError = error
       console.warn(
         `WAIT ${label}: ${error instanceof Error ? error.message : String(error)}`,
       )
-      await new Promise((resolve) => setTimeout(resolve, 10_000))
+      attempt += 1
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
   }
   throw lastError
+}
+
+export const withCacheBuster = (url, nonce, attempt) => {
+  const requestUrl = new URL(url)
+  requestUrl.searchParams.set("deployment-check", `${nonce}-${attempt}`)
+  return requestUrl
 }
 
 const checks = [
@@ -62,118 +62,159 @@ const checks = [
     path: "/cutover-smoke-test-not-found",
     status: 404,
     contentType: "text/html",
+    cacheBust: true,
+    timeoutMs: 5 * 60_000,
   },
 ]
 
-for (const check of checks) {
-  const url = new URL(check.path, baseUrl)
-  await retry(url.href, async () => {
-    const response = await fetch(url, {
-      redirect: "follow",
-      signal: AbortSignal.timeout(30_000),
-    })
-    if (response.status !== check.status) {
-      throw new Error(
-        `${url.href} returned ${response.status}; expected ${check.status}`,
-      )
-    }
-    const contentType = response.headers.get("content-type") ?? ""
-    const expectedContentTypes = Array.isArray(check.contentType)
-      ? check.contentType
-      : [check.contentType]
-    if (
-      !expectedContentTypes.some((expected) => contentType.includes(expected))
-    ) {
-      throw new Error(
-        `${url.href} returned content-type ${JSON.stringify(contentType)}; expected ${expectedContentTypes.join(" or ")}`,
-      )
-    }
-    if (
-      check.isolated &&
-      (response.headers.get("cross-origin-embedder-policy") !==
-        "require-corp" ||
-        response.headers.get("cross-origin-opener-policy") !== "same-origin")
-    ) {
-      throw new Error(`${url.href} is missing the playground isolation headers`)
-    }
-    if (check.path === "/" && expectedRevision !== undefined) {
-      const html = await response.text()
-      const marker = `name="effect-website-revision" content="${expectedRevision}"`
-      if (!html.includes(marker)) {
-        throw new Error(
-          `${url.href} does not contain revision ${expectedRevision}`,
-        )
-      }
-    }
-    console.log(`PASS ${response.status} ${url.href}`)
-  })
-}
+const main = async () => {
+  const [baseUrlArgument, trafficMode, expectedRevision] = process.argv.slice(2)
+  if (baseUrlArgument === undefined || !trafficModes.has(trafficMode)) {
+    throw new Error(
+      "Usage: verify-cloudflare-deployment.mjs <base-url> <traffic-mode>",
+    )
+  }
 
-const legacyApiSource = new URL("/docs/api/v4/effect/Effect?cutover=1", baseUrl)
-await retry(legacyApiSource.href, async () => {
-  const response = await fetch(legacyApiSource, {
-    redirect: "manual",
-    signal: AbortSignal.timeout(30_000),
-  })
-  if (response.status !== 308) {
-    throw new Error(
-      `${legacyApiSource.href} returned ${response.status}; expected 308`,
+  const baseUrl = new URL(baseUrlArgument)
+  if (baseUrl.protocol !== "https:") {
+    throw new Error(`Deployment URL must use HTTPS: ${baseUrl.href}`)
+  }
+
+  const probeNonce = Date.now().toString(36)
+  for (const check of checks) {
+    const url = new URL(check.path, baseUrl)
+    await retry(
+      url.href,
+      async (attempt) => {
+        const requestUrl = check.cacheBust
+          ? withCacheBuster(url, probeNonce, attempt)
+          : url
+        const response = await fetch(requestUrl, {
+          redirect: "follow",
+          signal: AbortSignal.timeout(30_000),
+        })
+        if (response.status !== check.status) {
+          throw new Error(
+            `${requestUrl.href} returned ${response.status}; expected ${check.status}`,
+          )
+        }
+        const contentType = response.headers.get("content-type") ?? ""
+        const expectedContentTypes = Array.isArray(check.contentType)
+          ? check.contentType
+          : [check.contentType]
+        if (
+          !expectedContentTypes.some((expected) =>
+            contentType.includes(expected),
+          )
+        ) {
+          throw new Error(
+            `${requestUrl.href} returned content-type ${JSON.stringify(contentType)}; expected ${expectedContentTypes.join(" or ")}`,
+          )
+        }
+        if (
+          check.isolated &&
+          (response.headers.get("cross-origin-embedder-policy") !==
+            "require-corp" ||
+            response.headers.get("cross-origin-opener-policy") !==
+              "same-origin")
+        ) {
+          throw new Error(
+            `${requestUrl.href} is missing the playground isolation headers`,
+          )
+        }
+        if (check.path === "/" && expectedRevision !== undefined) {
+          const html = await response.text()
+          const marker = `name="effect-website-revision" content="${expectedRevision}"`
+          if (!html.includes(marker)) {
+            throw new Error(
+              `${requestUrl.href} does not contain revision ${expectedRevision}`,
+            )
+          }
+        }
+        console.log(`PASS ${response.status} ${requestUrl.href}`)
+      },
+      check.timeoutMs === undefined
+        ? undefined
+        : { timeoutMs: check.timeoutMs },
     )
   }
-  const location = response.headers.get("location")
-  const destination =
-    location === null ? undefined : new URL(location, legacyApiSource)
-  const expected = new URL("/docs/v4/api/effect/Effect?cutover=1", baseUrl)
-  if (destination?.href !== expected.href) {
-    throw new Error(
-      `${legacyApiSource.href} redirected to ${destination?.href ?? "no location"}; expected ${expected.href}`,
-    )
-  }
-  console.log(
-    `PASS ${response.status} ${legacyApiSource.href} -> ${destination.href}`,
+
+  const legacyApiSource = new URL(
+    "/docs/api/v4/effect/Effect?cutover=1",
+    baseUrl,
   )
-})
-
-if (trafficMode !== "workers-dev") {
-  await retry("production origin", async () => {
-    const rootResponse = await fetch(new URL("/", baseUrl), {
+  await retry(legacyApiSource.href, async () => {
+    const response = await fetch(legacyApiSource, {
       redirect: "manual",
       signal: AbortSignal.timeout(30_000),
     })
-    if (
-      rootResponse.headers.get("server")?.toLowerCase() === "vercel" ||
-      rootResponse.headers.has("x-vercel-id")
-    ) {
-      throw new Error(`${baseUrl.href} is still served by Vercel`)
-    }
-  })
-
-  const redirectSource = new URL(
-    "https://www.effect.website/docs/v4/onboarding?cutover=1",
-  )
-  await retry(redirectSource.href, async () => {
-    const redirectResponse = await fetch(redirectSource, {
-      redirect: "manual",
-      signal: AbortSignal.timeout(30_000),
-    })
-    if (![301, 302, 307, 308].includes(redirectResponse.status)) {
+    if (response.status !== 308) {
       throw new Error(
-        `${redirectSource.href} returned ${redirectResponse.status}; expected a redirect`,
+        `${legacyApiSource.href} returned ${response.status}; expected 308`,
       )
     }
-    const location = redirectResponse.headers.get("location")
-    if (location === null) {
-      throw new Error(`${redirectSource.href} returned no redirect location`)
-    }
-    const destination = new URL(location, redirectSource)
-    const expected = "https://effect.website/docs/v4/onboarding?cutover=1"
-    if (destination.href !== expected) {
+    const location = response.headers.get("location")
+    const destination =
+      location === null ? undefined : new URL(location, legacyApiSource)
+    const expected = new URL("/docs/v4/api/effect/Effect?cutover=1", baseUrl)
+    if (destination?.href !== expected.href) {
       throw new Error(
-        `${redirectSource.href} redirected to ${destination.href}; expected ${expected}`,
+        `${legacyApiSource.href} redirected to ${destination?.href ?? "no location"}; expected ${expected.href}`,
       )
     }
     console.log(
-      `PASS ${redirectResponse.status} ${redirectSource.href} -> ${destination.href}`,
+      `PASS ${response.status} ${legacyApiSource.href} -> ${destination.href}`,
     )
   })
+
+  if (trafficMode !== "workers-dev") {
+    await retry("production origin", async () => {
+      const rootResponse = await fetch(new URL("/", baseUrl), {
+        redirect: "manual",
+        signal: AbortSignal.timeout(30_000),
+      })
+      if (
+        rootResponse.headers.get("server")?.toLowerCase() === "vercel" ||
+        rootResponse.headers.has("x-vercel-id")
+      ) {
+        throw new Error(`${baseUrl.href} is still served by Vercel`)
+      }
+    })
+
+    const redirectSource = new URL(
+      "https://www.effect.website/docs/v4/onboarding?cutover=1",
+    )
+    await retry(redirectSource.href, async () => {
+      const redirectResponse = await fetch(redirectSource, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(30_000),
+      })
+      if (![301, 302, 307, 308].includes(redirectResponse.status)) {
+        throw new Error(
+          `${redirectSource.href} returned ${redirectResponse.status}; expected a redirect`,
+        )
+      }
+      const location = redirectResponse.headers.get("location")
+      if (location === null) {
+        throw new Error(`${redirectSource.href} returned no redirect location`)
+      }
+      const destination = new URL(location, redirectSource)
+      const expected = "https://effect.website/docs/v4/onboarding?cutover=1"
+      if (destination.href !== expected) {
+        throw new Error(
+          `${redirectSource.href} redirected to ${destination.href}; expected ${expected}`,
+        )
+      }
+      console.log(
+        `PASS ${redirectResponse.status} ${redirectSource.href} -> ${destination.href}`,
+      )
+    })
+  }
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main()
 }

--- a/apps/web/test/scripts/verify-cloudflare-deployment.test.ts
+++ b/apps/web/test/scripts/verify-cloudflare-deployment.test.ts
@@ -1,0 +1,32 @@
+import { assert, test } from "vite-plus/test"
+import {
+  retry,
+  withCacheBuster,
+} from "../../scripts/verify-cloudflare-deployment.mjs"
+
+test("retries with an incrementing attempt number", async () => {
+  const attempts: Array<number> = []
+  const result = await retry(
+    "deployment",
+    async (attempt) => {
+      attempts.push(attempt)
+      if (attempt < 2) throw new Error("not ready")
+      return "ready"
+    },
+    { timeoutMs: 1_000, delayMs: 0 },
+  )
+
+  assert.equal(result, "ready")
+  assert.deepEqual(attempts, [0, 1, 2])
+})
+
+test("uses a distinct cache key for each deployment check", () => {
+  const url = new URL("https://preview.example/not-found?existing=value")
+  const first = withCacheBuster(url, "run", 0)
+  const second = withCacheBuster(url, "run", 1)
+
+  assert.equal(first.searchParams.get("existing"), "value")
+  assert.equal(first.searchParams.get("deployment-check"), "run-0")
+  assert.equal(second.searchParams.get("deployment-check"), "run-1")
+  assert.equal(url.searchParams.has("deployment-check"), false)
+})


### PR DESCRIPTION
## Summary

- check out the merged revision when cleaning up merged pull request previews
- configure Cloudflare to serve the generated 404 page explicitly
- avoid cached 404 probe responses and allow extra propagation time
- report accurate recovery guidance for private workers.dev deployments

## Verification

- `vp run check`
- `vp run test`
- focused deployment verification tests
- smoke verification against the deployed Cloudflare Worker