### PR TITLE
Fix migration regressions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -120,9 +120,3 @@ jobs:
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
           WEBSITE_REVISION: ${{ github.event.pull_request.merged && github.event.pull_request.merge_commit_sha || github.event.pull_request.base.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Delete Mixedbread preview store
-        if: always()
-        run: vp exec mixedbread delete-preview --pr "${{ github.event.pull_request.number }}"
-        env:
-          MXBAI_ADMIN_API_KEY: ${{ secrets.MXBAI_PREVIEW_ADMIN_API_KEY }}

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -54,7 +54,6 @@ const Website = (storeId: Input<string | Redacted.Redacted<string>>) =>
         astro: { output: "static" as const },
         assets: {
           htmlHandling: "drop-trailing-slash" as const,
-          notFoundHandling: "404-page" as const,
         },
         ...(stage === "prod"
           ? {

--- a/apps/web/scripts/verify-cloudflare-deployment.mjs
+++ b/apps/web/scripts/verify-cloudflare-deployment.mjs
@@ -50,6 +50,12 @@ const checks = [
     status: 200,
     contentType: "text/html",
   },
+  {
+    path: "/og/docs/v4/error-management/unexpected-errors.png",
+    status: 200,
+    contentType: "image/png",
+    cacheBust: true,
+  },
   { path: "/play", status: 200, contentType: "text/html", isolated: true },
   { path: "/robots.txt", status: 200, contentType: "text/plain" },
   { path: "/rss.xml", status: 200, contentType: "application/xml" },

--- a/apps/web/src/features/playground/atoms/import.ts
+++ b/apps/web/src/features/playground/atoms/import.ts
@@ -13,6 +13,7 @@ import {
   effectVersionForCodeLink,
   makeDefaultWorkspace,
   makeFile,
+  normalizeWorkspace,
   Workspace,
 } from "../domain/workspace"
 import { WorkspaceCompression } from "../services/compression"
@@ -238,7 +239,7 @@ export const importAtom = runtime.atom(
       yield* Effect.logInfo(
         "Playground: loaded workspace from the localStorage autosave",
       )
-      return autoSaved.value
+      return normalizeWorkspace(autoSaved.value)
     }
 
     const version = Option.getOrElse(get(versionParamAtom), () =>

--- a/apps/web/src/features/playground/domain/workspace.ts
+++ b/apps/web/src/features/playground/domain/workspace.ts
@@ -6,6 +6,7 @@ import { pipe } from "effect/Function"
 import * as Hash from "effect/Hash"
 import * as Iterable from "effect/Iterable"
 import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
 import * as Schema from "effect/Schema"
 import { DocsVersion, defaultDocsVersion } from "@/lib/versions"
 
@@ -564,4 +565,195 @@ const defaultWorkspaces: Record<EffectVersion, Workspace> = {
 
 export function makeDefaultWorkspace(version: EffectVersion): Workspace {
   return defaultWorkspaces[version]
+}
+
+const encodeJson = Schema.encodeUnknownSync(
+  Schema.fromJsonString(Schema.Json, {
+    replacer: undefined,
+    space: 2,
+  }),
+)
+const parseJson = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Json))
+
+function patchPackageJson(content: string): string | undefined {
+  // Invalid JSON (e.g. a mid-edit autosave) is left alone so the next save
+  // captures the finished edit instead of discarding it.
+  const parsed = Option.getOrUndefined(parseJson(content))
+  if (!Predicate.isObject(parsed)) {
+    return undefined
+  }
+  if (parsed["type"] === "module") {
+    return undefined
+  }
+  parsed["type"] = "module"
+  return encodeJson(parsed)
+}
+
+function patchTsConfig(content: string): string | undefined {
+  const parsed = Option.getOrUndefined(parseJson(content))
+  if (!Predicate.isObject(parsed)) {
+    return undefined
+  }
+  const compilerOptions = Predicate.isObject(parsed["compilerOptions"])
+    ? parsed["compilerOptions"]
+    : {}
+  if (
+    compilerOptions["module"] === "NodeNext" &&
+    compilerOptions["moduleResolution"] === "NodeNext"
+  ) {
+    return undefined
+  }
+  compilerOptions["module"] = "NodeNext"
+  compilerOptions["moduleResolution"] = "NodeNext"
+  return encodeJson(parsed)
+}
+
+const importSpecifierPattern =
+  /((?:import|export)[^'"`;]*?from\s*|(?:^|;)\s*import\s*|import\s*\(\s*)(['"])(\.\.?\/[^'"]*)\2/g
+
+function normalizePosixPath(path: string): string {
+  const absolute = path.startsWith("/")
+  const segments = path.split("/")
+  const out: Array<string> = []
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") {
+      continue
+    }
+    if (segment === "..") {
+      out.pop()
+      continue
+    }
+    out.push(segment)
+  }
+  return (absolute ? "/" : "") + out.join("/")
+}
+
+function resolveRelativePath(importerPath: string, specifier: string): string {
+  const directory = importerPath.includes("/")
+    ? importerPath.slice(0, importerPath.lastIndexOf("/"))
+    : ""
+  return normalizePosixPath(`${directory}/${specifier}`)
+}
+
+function hasExtension(specifier: string): boolean {
+  const lastSegment = specifier.slice(specifier.lastIndexOf("/") + 1)
+  return lastSegment.includes(".")
+}
+
+/**
+ * Appends `.js` to extensionless relative imports when the target exists in
+ * the workspace as a TypeScript file. Directory imports resolve to
+ * `./dir/index.js`. Unknown targets are left untouched.
+ */
+export function patchRelativeImports(
+  content: string,
+  importerPath: string,
+  files: ReadonlySet<string>,
+): string {
+  return content.replace(
+    importSpecifierPattern,
+    (match, prefix: string, quote: string, specifier: string) => {
+      if (specifier.endsWith("/") || hasExtension(specifier)) {
+        return match
+      }
+      const resolved = resolveRelativePath(importerPath, specifier)
+      if (files.has(`${resolved}.ts`) || files.has(`${resolved}.tsx`)) {
+        return `${prefix}${quote}${specifier}.js${quote}`
+      }
+      if (
+        files.has(`${resolved}/index.ts`) ||
+        files.has(`${resolved}/index.tsx`)
+      ) {
+        return `${prefix}${quote}${specifier}/index.js${quote}`
+      }
+      return match
+    },
+  )
+}
+
+function patchFileContent(
+  path: string,
+  content: string,
+  files: ReadonlySet<string>,
+): string | undefined {
+  if (path === "package.json") {
+    return patchPackageJson(content)
+  }
+  if (path === "tsconfig.json") {
+    return patchTsConfig(content)
+  }
+  if (path.endsWith(".ts") || path.endsWith(".tsx")) {
+    const patched = patchRelativeImports(content, path, files)
+    return patched === content ? undefined : patched
+  }
+  return undefined
+}
+
+function mapTree(
+  tree: FileTree,
+  f: (file: File, path: string) => File,
+): { tree: FileTree; changed: boolean } {
+  let changed = false
+  const walk = (prefix: string, children: FileTree): FileTree =>
+    children.map((node) => {
+      if (node._tag === "Directory") {
+        const next = walk(`${prefix}${node.name}/`, node.children)
+        if (next === node.children) {
+          return node
+        }
+        changed = true
+        return makeDirectory(node.name, next, node.userManaged ?? false)
+      }
+      const path = `${prefix}${node.name}`
+      const replacement = f(node, path)
+      if (replacement !== node) {
+        changed = true
+      }
+      return replacement
+    })
+  const next = walk("", tree)
+  return { tree: next, changed: changed || next !== tree }
+}
+
+/**
+ * Repairs workspaces persisted before the ESM fixes: `package.json` without
+ * `"type": "module"`, `tsconfig.json` without `NodeNext` module settings,
+ * `prepare` commands using npm, missing generated configs, and extensionless
+ * relative imports which fail under `NodeNext`.
+ *
+ * User code is preserved: only the fields above are patched, invalid JSON
+ * (e.g. a mid-edit autosave) is left untouched, and custom dependencies and
+ * extra files pass through unchanged.
+ */
+export function normalizeWorkspace(workspace: Workspace): Workspace {
+  let result = workspace
+  if (result.prepare.trim() !== "pnpm install") {
+    result = result.withPrepare("pnpm install")
+  }
+  const reference = makeDefaultWorkspace(result.effectVersion)
+  const files = new Set<string>()
+  for (const [node, path] of result.filePaths) {
+    if (node._tag === "File") {
+      files.add(path)
+    }
+  }
+  const mapped = mapTree(result.tree, (file, path) => {
+    const patched = patchFileContent(path, file.initialContent, files)
+    return patched === undefined ? file : file.withContent(patched)
+  })
+  result = mapped.changed ? result.setTree(mapped.tree) : result
+  const missing: Array<File> = []
+  for (const name of [
+    "package.json",
+    "tsconfig.json",
+    "dprint.json",
+  ] as const) {
+    if (Option.isNone(result.findFile(name))) {
+      const fallback = reference.findFile(name)
+      if (Option.isSome(fallback)) {
+        missing.push(fallback.value[0])
+      }
+    }
+  }
+  return missing.length > 0 ? result.append(...missing) : result
 }

--- a/apps/web/src/features/playground/services/compression.ts
+++ b/apps/web/src/features/playground/services/compression.ts
@@ -3,7 +3,7 @@ import * as Data from "effect/Data"
 import * as Encoding from "effect/Encoding"
 import { flow, pipe } from "effect/Function"
 import * as Schema from "effect/Schema"
-import { Workspace } from "../domain/workspace"
+import { Workspace, normalizeWorkspace } from "../domain/workspace"
 
 export class CompressionError extends Data.TaggedError("CompressionError")<{
   readonly method: "compress" | "decompress"
@@ -113,8 +113,10 @@ export class WorkspaceCompression extends Context.Service<WorkspaceCompression>(
         pipe(
           compression.decompressBase64(compressed),
           Effect.andThen(decodeWorkspace),
-          // Older shared playgrounds may persist npm, but type acquisition expects pnpm's store.
-          Effect.map((workspace) => workspace.withPrepare("pnpm install")),
+          // Older shared playgrounds persist npm commands, CommonJS
+          // package.json files, and extensionless imports. Type acquisition
+          // expects pnpm's store and NodeNext ESM, so normalize on load.
+          Effect.map(normalizeWorkspace),
         )
 
       return { compress, decompress, snapshot } as const

--- a/apps/web/test/features/playground/migration.test.ts
+++ b/apps/web/test/features/playground/migration.test.ts
@@ -1,0 +1,223 @@
+import * as Option from "effect/Option"
+import { assert, test } from "vite-plus/test"
+import {
+  makeDefaultWorkspace,
+  makeFile,
+  normalizeWorkspace,
+} from "../../../src/features/playground/domain/workspace.ts"
+
+function staleV3() {
+  const workspace = makeDefaultWorkspace("v3")
+  const [packageJson] = workspace
+    .findFile("package.json")
+    .pipe(Option.getOrThrow)
+  // Pre-ESM autosaves persisted dependencies without "type": "module".
+  const withoutType = workspace.replaceNode(
+    packageJson,
+    makeFile(
+      "package.json",
+      JSON.stringify({ dependencies: { effect: "latest" } }, undefined, 2),
+    ),
+  )
+  const [main] = withoutType.findFile("src/main.ts").pipe(Option.getOrThrow)
+  const extensionless = withoutType.replaceNode(
+    main,
+    main.withContent(
+      main.initialContent.replace('"./DevTools.js"', '"./DevTools"'),
+    ),
+  )
+  return extensionless.withPrepare("npm install")
+}
+
+test("adds type module while preserving dependencies", () => {
+  const normalized = normalizeWorkspace(staleV3())
+  const [packageJson] = normalized
+    .findFile("package.json")
+    .pipe(Option.getOrThrow)
+  const parsed = JSON.parse(packageJson.initialContent)
+
+  assert.equal(parsed.type, "module")
+  assert.deepEqual(parsed.dependencies, { effect: "latest" })
+})
+
+test("normalizes npm prepare to pnpm install", () => {
+  assert.equal(normalizeWorkspace(staleV3()).prepare, "pnpm install")
+})
+
+test("fixes extensionless DevTools import and keeps user code", () => {
+  const normalized = normalizeWorkspace(staleV3())
+  const [main] = normalized.findFile("src/main.ts").pipe(Option.getOrThrow)
+
+  assert.match(main.initialContent, /from "\.\/DevTools\.js"/)
+  assert.notMatch(main.initialContent, /from "\.\/DevTools"(?!\.)/)
+  assert.match(main.initialContent, /Welcome to the Effect Playground!/)
+})
+
+test("restores missing generated configs", () => {
+  const workspace = makeDefaultWorkspace("v3")
+  const [tsconfig] = workspace.findFile("tsconfig.json").pipe(Option.getOrThrow)
+  const without = workspace.removeNode(tsconfig)
+  const normalized = normalizeWorkspace(without)
+
+  const [restored] = normalized
+    .findFile("tsconfig.json")
+    .pipe(Option.getOrThrow)
+  const parsed = JSON.parse(restored.initialContent)
+  assert.equal(parsed.compilerOptions.module, "NodeNext")
+  assert.equal(parsed.compilerOptions.moduleResolution, "NodeNext")
+})
+
+test("patches tsconfig module settings while keeping other options", () => {
+  const workspace = makeDefaultWorkspace("v3")
+  const [tsconfig] = workspace.findFile("tsconfig.json").pipe(Option.getOrThrow)
+  const stale = workspace.replaceNode(
+    tsconfig,
+    tsconfig.withContent(
+      JSON.stringify(
+        {
+          compilerOptions: { module: "commonjs", strict: false },
+          include: ["src"],
+        },
+        undefined,
+        2,
+      ),
+    ),
+  )
+  const normalized = normalizeWorkspace(stale)
+  const [patched] = normalized.findFile("tsconfig.json").pipe(Option.getOrThrow)
+  const parsed = JSON.parse(patched.initialContent)
+
+  assert.equal(parsed.compilerOptions.module, "NodeNext")
+  assert.equal(parsed.compilerOptions.moduleResolution, "NodeNext")
+  assert.equal(parsed.compilerOptions.strict, false)
+  assert.deepEqual(parsed.include, ["src"])
+})
+
+test("leaves invalid package.json alone so mid-edit autosaves survive", () => {
+  const workspace = makeDefaultWorkspace("v3")
+  const [packageJson] = workspace
+    .findFile("package.json")
+    .pipe(Option.getOrThrow)
+  const midEdit = workspace.replaceNode(
+    packageJson,
+    packageJson.withContent('{"dependencies": {'),
+  )
+  const normalized = normalizeWorkspace(midEdit)
+  const [kept] = normalized.findFile("package.json").pipe(Option.getOrThrow)
+
+  assert.equal(kept.initialContent, '{"dependencies": {')
+})
+
+test("leaves non-object package.json alone", () => {
+  const workspace = makeDefaultWorkspace("v3")
+  const [packageJson] = workspace
+    .findFile("package.json")
+    .pipe(Option.getOrThrow)
+  const array = workspace.replaceNode(
+    packageJson,
+    packageJson.withContent("[]"),
+  )
+  const normalized = normalizeWorkspace(array)
+  const [kept] = normalized.findFile("package.json").pipe(Option.getOrThrow)
+
+  assert.equal(kept.initialContent, "[]")
+})
+
+test("keeps custom dependencies and user files", () => {
+  const workspace = makeDefaultWorkspace("v3")
+  const [packageJson] = workspace
+    .findFile("package.json")
+    .pipe(Option.getOrThrow)
+  const custom = workspace
+    .replaceNode(
+      packageJson,
+      makeFile(
+        "package.json",
+        JSON.stringify(
+          { dependencies: { effect: "latest", lodash: "4.17.21" } },
+          undefined,
+          2,
+        ),
+      ),
+    )
+    .append(makeFile("notes.txt", "do not touch", true))
+  const normalized = normalizeWorkspace(custom)
+  const [parsed] = normalized.findFile("package.json").pipe(Option.getOrThrow)
+
+  assert.equal(JSON.parse(parsed.initialContent).dependencies.lodash, "4.17.21")
+  const [notes] = normalized.findFile("notes.txt").pipe(Option.getOrThrow)
+  assert.equal(notes.initialContent, "do not touch")
+})
+
+test("current defaults are already normalized", () => {
+  for (const version of ["v3", "v4"] as const) {
+    const workspace = makeDefaultWorkspace(version)
+    const normalized = normalizeWorkspace(workspace)
+    assert.equal(normalized.prepare, "pnpm install")
+    const [packageJson] = normalized
+      .findFile("package.json")
+      .pipe(Option.getOrThrow)
+    assert.equal(JSON.parse(packageJson.initialContent).type, "module")
+  }
+})
+
+test("fixes extensionless imports in user-defined files", () => {
+  const workspace = makeDefaultWorkspace("v3").append(
+    makeFile(
+      "src/user.ts",
+      `import { helper } from "./helper"\nimport { other } from "../other"\nexport const value = 1\n`,
+      true,
+    ),
+    makeFile("src/helper.ts", `export const helper = 1\n`, true),
+    makeFile("other.ts", `export const other = 1\n`, true),
+  )
+  const normalized = normalizeWorkspace(workspace)
+  const [user] = normalized.findFile("src/user.ts").pipe(Option.getOrThrow)
+
+  assert.match(user.initialContent, /from "\.\/helper\.js"/)
+  assert.match(user.initialContent, /from "\.\.\/other\.js"/)
+})
+
+test("fixes side-effect, dynamic, and re-export imports", () => {
+  const workspace = makeDefaultWorkspace("v3").append(
+    makeFile(
+      "src/user.ts",
+      `import "./side-effect"\nconst mod = await import("./helper")\nexport * from "./helper"\n`,
+      true,
+    ),
+    makeFile("src/side-effect.ts", `console.log("side")\n`, true),
+    makeFile("src/helper.ts", `export const helper = 1\n`, true),
+  )
+  const normalized = normalizeWorkspace(workspace)
+  const [user] = normalized.findFile("src/user.ts").pipe(Option.getOrThrow)
+
+  assert.match(user.initialContent, /import "\.\/side-effect\.js"/)
+  assert.match(user.initialContent, /import\("\.\/helper\.js"\)/)
+  assert.match(user.initialContent, /export \* from "\.\/helper\.js"/)
+})
+
+test("resolves directory imports to index.js", () => {
+  const workspace = makeDefaultWorkspace("v3").append(
+    makeFile(`src/user.ts`, `import { util } from "./utils"\n`, true),
+    makeFile("src/utils/index.ts", `export const util = 1\n`, true),
+  )
+  const normalized = normalizeWorkspace(workspace)
+  const [user] = normalized.findFile("src/user.ts").pipe(Option.getOrThrow)
+
+  assert.match(user.initialContent, /from "\.\/utils\/index\.js"/)
+})
+
+test("leaves package imports, extensions, and unknown targets alone", () => {
+  const source = `import { Effect } from "effect"\nimport { helper } from "./helper.js"\nimport { missing } from "./missing"\n`
+  const workspace = makeDefaultWorkspace("v3").append(
+    makeFile("src/user.ts", source, true),
+    makeFile("src/helper.ts", `export const helper = 1\n`, true),
+  )
+  const normalized = normalizeWorkspace(workspace)
+  const [user] = normalized.findFile("src/user.ts").pipe(Option.getOrThrow)
+
+  assert.match(user.initialContent, /from "effect"/)
+  assert.match(user.initialContent, /from "\.\/helper\.js"/)
+  assert.match(user.initialContent, /from "\.\/missing"/)
+  assert.notMatch(user.initialContent, /missing\.js/)
+})


### PR DESCRIPTION
## Summary

- normalize persisted playground workspaces for pnpm and NodeNext ESM
- remove redundant Mixedbread preview-store cleanup
- let dynamic Astro routes handle asset misses and smoke-test generated Open Graph images

## Validation

- `vp check`
- `vp test` (30 files, 335 tests)